### PR TITLE
chore: bump heimdall to 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ polygon_pos_package:
       # The docker image that should be used for the CL client.
       # Leave blank to use the default image for the client type.
       # Defaults by client:
-      # - heimdall: "0xpolygon/heimdall:1.0.10"
+      # - heimdall: "0xpolygon/heimdall:1.2.0"
       # - heimdall-v2: TDB
       cl_image: ""
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,6 +23,6 @@ docker push leovct/pos-el-genesis-builder:node-16
 - [Docker Hub](https://hub.docker.com/r/leovct/pos-validator-config-generator)
 
 ```bash
-docker build --tag leovct/pos-validator-config-generator:1.0.10 --file pos-validator-config-generator.Dockerfile .
-docker push leovct/pos-validator-config-generator:1.0.10
+docker build --tag leovct/pos-validator-config-generator:1.2.0 --file pos-validator-config-generator.Dockerfile .
+docker push leovct/pos-validator-config-generator:1.2.0
 ```

--- a/docker/pos-validator-config-generator.Dockerfile
+++ b/docker/pos-validator-config-generator.Dockerfile
@@ -1,4 +1,4 @@
-FROM 0xpolygon/heimdall:1.0.10 AS heimdall
+FROM 0xpolygon/heimdall:1.2.0 AS heimdall
 
 
 FROM golang:1.22 AS polycli-builder

--- a/src/package_io/input_parser.star
+++ b/src/package_io/input_parser.star
@@ -5,7 +5,7 @@ sanity_check = import_module("./sanity_check.star")
 DEFAULT_POS_CONTRACT_DEPLOYER_IMAGE = "leovct/pos-contract-deployer:node-16"
 DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:node-16"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = (
-    "leovct/pos-validator-config-generator:1.0.10"  # based on 0xpolygon/heimdall:1.0.10
+    "leovct/pos-validator-config-generator:1.2.0"  # based on 0xpolygon/heimdall:1.2.0
 )
 
 DEFAULT_EL_IMAGES = {
@@ -14,7 +14,7 @@ DEFAULT_EL_IMAGES = {
 }
 
 DEFAULT_CL_IMAGES = {
-    constants.CL_TYPE.heimdall: "0xpolygon/heimdall:1.0.10",
+    constants.CL_TYPE.heimdall: "0xpolygon/heimdall:1.2.0",
 }
 
 DEFAULT_CL_DB_IMAGE = "rabbitmq:4.0.5"


### PR DESCRIPTION
## Description

Closes #40 

1. Bump the version of the default heimdall client: `0xpolygon/heimdall:1.2.0`
2. Build a new version of the validator config generator based on this new version of heimdall: `leovct/pos-validator-config-generator:1.2.0`
