### PR TITLE
ci: allow to pull `leovct/heimdall-v2` private image

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,11 +46,6 @@ jobs:
         with:
           version: ${{ env.FOUNDRY_VERSION }}
 
-      - name: Install yq
-        run: |
-          pip3 install yq
-          yq --version
-
       - name: Run Starlark
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --show-enclave-inspect=false .
 
@@ -151,6 +146,11 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: ${{ env.FOUNDRY_VERSION }}
+
+      - name: Install yq
+        run: |
+          pip3 install yq
+          yq --version
 
       - name: Get heimdall-v2 private image
         run: docker pull leovct/heimdall-v2:e0a87ca


### PR DESCRIPTION
The heimdall-v2 repository is private for the moment, so the `leovct/heimdall-v2` image is now also private and requires a token to access it. Credentials are needed to pull the image, they can be retrieved in 1password under the name "Kurtosis PoS // Heimdall-v2".

Another thing, since the image has only been built for `linux/amd64`, there's no docker manifest. This is a quick fix to make Kurtosis work when trying to pull this image.