### PR TITLE
feat: bump bor to `2.1.1`

### DIFF
--- a/.github/configs/nightly/all.yml
+++ b/.github/configs/nightly/all.yml
@@ -17,7 +17,7 @@ polygon_pos_package:
   participants:
     - kind: validator
       el_type: bor
-      el_image: 0xpolygon/bor:2.1.0
+      el_image: 0xpolygon/bor:2.1.1
       el_log_level: info
       cl_type: heimdall
       cl_image: 0xpolygon/heimdall:1.2.3

--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -70,7 +70,7 @@ Default: two validators and one rpc.
 | cl_db_image   | string | rabbitmq:4.1.0       | Image for the CL database.                                                                  |
 | cl_log_level  | string | info                 | Log level for the CL client.                                                                |
 | el_type       | string | bor                  | Execution Layer (EL) client type.                                                           |
-| el_image      | string | 0xpolygon/bor:2.1.0  | Image for the EL client.                                                                    |
+| el_image      | string | 0xpolygon/bor:2.1.1  | Image for the EL client.                                                                    |
 | el_log_level  | string | info                 | Log level for the EL client.                                                                |
 | count         | int    | 1                    | Number of nodes to spin up for this participant.                                            |
 

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -7,7 +7,7 @@ DEFAULT_POS_EL_GENESIS_BUILDER_IMAGE = "leovct/pos-el-genesis-builder:96a19dd"
 DEFAULT_POS_VALIDATOR_CONFIG_GENERATOR_IMAGE = "leovct/pos-validator-config-generator:1.2.3-0.1.12"  # Based on 0xpolygon/heimdall:1.2.3 and 0xpolygon/heimdall-v2:0.1.12.
 
 DEFAULT_EL_IMAGES = {
-    constants.EL_TYPE.bor: "0xpolygon/bor:2.1.0",
+    constants.EL_TYPE.bor: "0xpolygon/bor:2.1.1",
     constants.EL_TYPE.bor_modified_for_heimdall_v2: "leovct/bor:84794ac",  # There is no official image yet.
     constants.EL_TYPE.erigon: "erigontech/erigon:main-latest",  # TODO: Use an official tag.
 }


### PR DESCRIPTION
https://github.com/maticnetwork/bor/releases/tag/v2.1.1