### PR TITLE
chore: use smaller value for stateSyncConfirmationDelay

### DIFF
--- a/static_files/el/genesis/genesis.json
+++ b/static_files/el/genesis/genesis.json
@@ -23,19 +23,19 @@
       "ahmedabadBlock": 0,
       "bhilaiBlock": 0,
       "stateSyncConfirmationDelay": {
-        "256": 128
+        "0": 32
       },
       "period": {
         "0": {{.el_block_interval_seconds}}
       },
       "producerDelay": {
-        "0": 5
+        "0": 2
       },
       "sprint": {
         "0": {{.el_sprint_duration}}
       },
       "backupMultiplier": {
-        "0": 5
+        "0": 2
       },
       "validatorContract": "0x0000000000000000000000000000000000001000",
       "stateReceiverContract": "0x0000000000000000000000000000000000001001",


### PR DESCRIPTION
# Description

`stateSyncConfirmationDelay` value is used in Bor to delay state syncs by that amount of time. Using a higher value in devnets is causing the state sync test in CI to run for around 3.5 minutes, which is a lot, to be honest. On a testing devnet where we don't care for confirmation delay much and just want to see state sync reach Bor as fast as possible, `32` seems to be a decent value. It gives just the right amount of delay and does not stretch the CI tests. With these config changes, state sync tests in CI would now pass in 1 min and 40 secs, which is a 2-minute reduction of time.

Other configs are ported from the `stateless` branch.