### PR TITLE
fix: voting_power bug in hv2

### DIFF
--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -46,7 +46,7 @@ DEFAULT_EL_CHAIN_ID = "4927"
 DEFAULT_CL_CHAIN_ID = "heimdall-4927"  # Follows the standard "heimdall-<el_chain_id>".
 
 ADMIN_BALANCE_ETH = math.pow(10, 9)
-VALIDATORS_BALANCE_ETH = math.pow(10, 9)
+VALIDATORS_BALANCE_ETH = math.pow(10, 4)
 
 CL_CLIENT_CONFIG_PATH = "/etc/cl"
 EL_CLIENT_CONFIG_PATH = "/etc/el"


### PR DESCRIPTION
# Description

We stake `10_000` POL on L1, but somehow we have had `10^9` voting_power in HV2. Ideally, we should have thrown an error from the HV2 side, but we did not.

Before:
```bash
for val in 1 2 3 4; do stake=$(cast call --rpc-url http://127.0.0.1:63329/ 0x62e60f7d720f15dCB66cB1f7990Fed740C6259c5 "totalValidatorStake(uint)(uint)" $val | cut -d' ' -f1); echo "Val $val: $(cast to-unit $stake ether) POL"; done
Val 1: 10000 POL
Val 2: 10000 POL
Val 3: 10000 POL
Val 4: 10000 POL

curl -s "http://127.0.0.1:63731/stake/validators-set" | jq '.validator_set.validators[] | "Val " + .val_id + ": " + .voting_power'
"Val 1: 1000000000"
"Val 3: 1000000000"
"Val 4: 1000000000"
"Val 2: 1000000000"
```

After:
```bash
for val in 1 2 3 4; do stake=$(cast call --rpc-url $L1_RPC_URL $L1_STAKING_INFO_ADDRESS "totalValidatorStake(uint)(uint)" $val | cut -d' ' -f1); echo "Val $val: $(cast to-unit $stake ether) POL";
done
Val 1: 10000 POL
Val 2: 10000 POL
Val 3: 10000 POL
Val 4: 10000 POL

curl -s "$L2_CL_API_URL/stake/validators-set" | jq '.validator_set.validators[] | "Val " + .val_id + ": " + .voting_power'
"Val 1: 10000"
"Val 3: 10000"
"Val 4: 10000"
"Val 2: 10000"
```


Verify the same thing on the mainnet for a sample val:
https://staking.polygon.technology/validators/8
https://heimdall-api.polygon.technology/stake/validator/8