### PR TITLE
ci: parse kurtosis execution time

### DIFF
--- a/.github/actions/kurtosis-pre-run/action.yml
+++ b/.github/actions/kurtosis-pre-run/action.yml
@@ -22,7 +22,7 @@ runs:
       run: |
         echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
         sudo apt update
-        sudo apt install -y kurtosis-cli=1.7.2
+        sudo apt install -y kurtosis-cli=1.10.3
         kurtosis analytics disable
         kurtosis version
 
@@ -35,7 +35,7 @@ runs:
     - name: Install foundry
       uses: foundry-rs/foundry-toolchain@de808b1eea699e761c404bda44ba8f21aba30b2c # v1.3.1
       with:
-        version: v1.0.0
+        version: v1.3.0
         cache: false
 
     # Login to registries

--- a/.github/scripts/parse_timing.py
+++ b/.github/scripts/parse_timing.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+Parse Kurtosis timing information from run logs.
+
+This script extracts the "Starlark code successfully run. Total instruction execution time"
+from Kurtosis logs and converts the time to seconds for analysis.
+"""
+
+import re
+import json
+import sys
+import argparse
+from typing import Optional, Dict, Any
+
+
+def parse_time_to_seconds(time_str: str) -> float:
+    """
+    Convert time string to seconds.
+
+    Supports formats like:
+    - "2m57.885776139s"
+    - "177.885776139s"
+    - "30000ms"
+    - "1h2m30s"
+    """
+    # Remove any whitespace
+    time_str = time_str.strip()
+
+    total_seconds = 0.0
+
+    # Handle hours (h)
+    hours_match = re.search(r'(\d+(?:\.\d+)?)h', time_str)
+    if hours_match:
+        total_seconds += float(hours_match.group(1)) * 3600
+
+    # Handle minutes (m) - but not 'ms'
+    minutes_match = re.search(r'(\d+(?:\.\d+)?)m(?!s)', time_str)
+    if minutes_match:
+        total_seconds += float(minutes_match.group(1)) * 60
+
+    # Handle seconds (s) - but not part of 'ms'
+    seconds_match = re.search(r'(\d+(?:\.\d+)?)s(?!\w)', time_str)
+    if seconds_match:
+        total_seconds += float(seconds_match.group(1))
+
+    # Handle milliseconds (ms)
+    ms_match = re.search(r'(\d+(?:\.\d+)?)ms', time_str)
+    if ms_match:
+        total_seconds += float(ms_match.group(1)) / 1000
+
+    # If no units found, assume it's already in seconds
+    if total_seconds == 0.0 and re.match(r'^\d+(?:\.\d+)?$', time_str):
+        total_seconds = float(time_str)
+
+    return total_seconds
+
+
+def extract_timing_from_log(log_file_path: str) -> Optional[Dict[str, Any]]:
+    """
+    Extract timing information from Kurtosis log file.
+
+    Returns dictionary with timing data or None if not found.
+    """
+    try:
+        with open(log_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except FileNotFoundError:
+        return None
+    except Exception as e:
+        print(f"Error reading log file: {e}", file=sys.stderr)
+        return None
+
+    # Pattern to match the timing line
+    pattern = r'Starlark code successfully run\.\s*Total instruction execution time:\s*([0-9hms.]+)\.'
+    matches = re.findall(pattern, content, re.IGNORECASE)
+    if not matches:
+        return None
+    raw_time = matches[-1]  # Use the last match if multiple found
+
+    try:
+        parsed_time = parse_time_to_seconds(raw_time)
+        return (raw_time, parsed_time)
+    except Exception as e:
+        print(f"Error parsing timing '{raw_time}': {e}", file=sys.stderr)
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Parse deployment timing from Kurtosis log files')
+    parser.add_argument('log_file', help='Path to the log file to parse')
+    parser.add_argument('--threshold', type=float, default=200.0,
+                        help='Maximum allowed execution time in seconds (default: 200)')
+    args = parser.parse_args()
+
+    (raw_time, parsed_time) = extract_timing_from_log(args.log_file)
+    if (raw_time, parsed_time) is None:
+        print(
+            f"No timing information found in {args.log_file}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Kurtosis execution times:")
+    print(f"- raw: {raw_time}")
+    print(f"- parsed: {parsed_time:.2f}s")
+    print(f"- threshold: {args.max_time:.1f}s")
+
+    if parsed_time > args.max_time:
+        print(f"❌ Error: execution time exceeds the threshold")
+        sys.exit(1)
+    else:
+        print(f"✅ Execution time is within the threshold")
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/scripts/parse_timing.py
+++ b/.github/scripts/parse_timing.py
@@ -102,9 +102,9 @@ def main():
     print("Kurtosis execution times:")
     print(f"- raw: {raw_time}")
     print(f"- parsed: {parsed_time:.2f}s")
-    print(f"- threshold: {args.max_time:.1f}s")
+    print(f"- threshold: {args.threshold:.1f}s")
 
-    if parsed_time > args.max_time:
+    if parsed_time > args.threshold:
         print(f"❌ Error: execution time exceeds the threshold")
         sys.exit(1)
     else:

--- a/.github/scripts/timing-thresholds.txt
+++ b/.github/scripts/timing-thresholds.txt
@@ -2,15 +2,15 @@
 # Format: <config-file-name>: <threshold_seconds>
 
 # Default threshold
-default: 200
+default: 210
 
 # Client configurations
-heimdall-v2-bor: 200
-heimdall-v2-erigon: 200
+heimdall-v2-bor: 210
+heimdall-v2-erigon: 210
 heimdall-v2-bor-minimal: 180
 heimdall-v2-erigon-minimal: 180
 
 # Additional services configurations
-additional-services: 200
-prometheus-grafana: 200
-test-runner: 200
+additional-services: 210
+prometheus-grafana: 210
+test-runner: 210

--- a/.github/scripts/timing-thresholds.txt
+++ b/.github/scripts/timing-thresholds.txt
@@ -1,0 +1,16 @@
+# Timing thresholds for different environments (in seconds)
+# Format: <config-file-name>: <threshold_seconds>
+
+# Default threshold
+default: 200
+
+# Client configurations
+heimdall-v2-bor: 200
+heimdall-v2-erigon: 200
+heimdall-v2-bor-minimal: 180
+heimdall-v2-erigon-minimal: 180
+
+# Additional services configurations
+additional-services: 200
+prometheus-grafana: 200
+test-runner: 200

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -31,7 +31,7 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Kurtosis run
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -90,7 +90,7 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Kurtosis run
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=${{ matrix.file.path }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   ENCLAVE_NAME: pos
-  EXECUTION_THRESHOLD_SECONDS: 200
 
 jobs:
   run-without-args:
@@ -35,7 +34,7 @@ jobs:
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed . 2>&1 | tee run.log
 
       - name: Extract timing information
-        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
+        run: python3 .github/scripts/parse_timing.py run.log
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -97,7 +96,7 @@ jobs:
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} . 2>&1 | tee run.log
 
       - name: Extract timing information
-        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
+        run: python3 .github/scripts/parse_timing.py run.log --config-file=${{ matrix.file.path }}
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -16,6 +16,7 @@ concurrency:
 
 env:
   ENCLAVE_NAME: pos
+  EXECUTION_THRESHOLD_SECONDS: 200
 
 jobs:
   run-without-args:
@@ -31,7 +32,10 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Kurtosis run
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed . 2>&1 | tee run.log
+
+      - name: Extract timing information
+        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -90,7 +94,10 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Kurtosis run
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} . 2>&1 | tee run.log
+
+      - name: Extract timing information
+        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/kurtosis-deploy.yaml
+++ b/.github/workflows/kurtosis-deploy.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   run-without-args:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -78,7 +78,7 @@ jobs:
     needs: [list-ymls]
     name: run-with-${{ matrix.file.name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   run-without-args:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -75,7 +75,7 @@ jobs:
     needs: list-ymls
     name: run-with-${{ matrix.file.name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +135,7 @@ jobs:
 
   run-with-external-l1:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -172,7 +172,7 @@ jobs:
 
   run-with-cl-el-genesis:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,6 @@ permissions:
 
 env:
   ENCLAVE_NAME: pos
-  EXECUTION_THRESHOLD_SECONDS: 200
 
 jobs:
   run-without-args:
@@ -32,7 +31,7 @@ jobs:
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed . 2>&1 | tee run.log
 
       - name: Extract timing information
-        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
+        run: python3 .github/scripts/parse_timing.py run.log
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -94,7 +93,7 @@ jobs:
         run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} . 2>&1 | tee run.log
 
       - name: Extract timing information
-        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
+        run: python3 .github/scripts/parse_timing.py run.log --config-file ${{ matrix.file.path }}
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,7 +28,10 @@ jobs:
           pull_images_from_gcr: "false"
 
       - name: Kurtosis run
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed . 2>&1 | tee run.log
+
+      - name: Extract timing information
+        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -87,7 +90,10 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Run Starlark
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} . 2>&1 | tee run.log
+
+      - name: Extract timing information
+        run: python3 .github/scripts/parse_timing.py run.log --threshold ${{ env.EXECUTION_THRESHOLD_SECONDS }}
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   ENCLAVE_NAME: pos
+  EXECUTION_THRESHOLD_SECONDS: 200
 
 jobs:
   run-without-args:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,7 +28,7 @@ jobs:
           pull_images_from_gcr: "false"
 
       - name: Kurtosis run
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -87,7 +87,7 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Run Starlark
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=${{ matrix.file.path }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=${{ matrix.file.path }} .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -140,10 +140,10 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Deploy L1
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file ./.github/configs/nightly/external-l1/ethereum.yml --verbosity=DETAILED github.com/ethpandaops/ethereum-package@1bf08937f7ec376d5e281fef87dc1efc28aeefef # 2025-06-14 (>v5.0.1)
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file ./.github/configs/nightly/external-l1/ethereum.yml --verbosity=DETAILED github.com/ethpandaops/ethereum-package@1bf08937f7ec376d5e281fef87dc1efc28aeefef # 2025-06-14 (>v5.0.1)
 
       - name: Deploy L2
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/configs/nightly/external-l1/polygon-pos-with-external-l1.yml .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=./.github/configs/nightly/external-l1/polygon-pos-with-external-l1.yml .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -177,7 +177,7 @@ jobs:
           docker_token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Kurtosis run for the first time
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}
@@ -212,7 +212,7 @@ jobs:
           kurtosis service stop ${{ env.ENCLAVE_NAME }} l2-el-3-bor-heimdall-v2-rpc
 
       - name: Kurtosis run for the second time
-        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --args-file=./.github/configs/nightly/cl-el-genesis/polygon-pos-with-cl-el-genesis.yml .
+        run: kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=./.github/configs/nightly/cl-el-genesis/polygon-pos-with-cl-el-genesis.yml .
 
       - name: Inspect enclave
         run: kurtosis enclave inspect ${{ env.ENCLAVE_NAME }}


### PR DESCRIPTION
- Run `kurtosis run` commands with `--verbosity detailed` to see the duration that each instructions take to execute as well as total instruction execution duration.
- Implement a python script, `.github/scripts/parse_timing.py`, to parse the total execution time and compare it again some thresholds (each environment defines its own thresholds in `.github/scripts/timing-thresholds.txt`).
- Make the CI fail if the package takes more time to deploy than it should.
- Reduce job timeouts (not related).
