### PR TITLE
chore: set bor.logs to true

### DIFF
--- a/static_files/el/bor/config.toml
+++ b/static_files/el/bor/config.toml
@@ -1,9 +1,10 @@
-identity = "{{.node_name}}"
 chain = "{{.config_folder_path}}/genesis.json"
 datadir = "{{.data_folder_path}}"
+identity = "{{.node_name}}"
+syncmode = "{{.sync_mode}}"
 verbosity = {{.log_level_to_int}}
 
-syncmode = "{{.sync_mode}}"
+"bor.logs" = true
 
 [p2p]
     maxpeers = 200


### PR DESCRIPTION
`bor.logs` is used to index state sync transactions.