### PR TITLE
feat: allow to customise the status checker image

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -120,3 +120,9 @@ The `additional_services` array lets you enable optional tools and utilities alo
 | Field | Type   | Default                                                                     | Description                                                                                               |
 | ----- | ------ | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
 | image | string | europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/e2e:026adc0 | Image used to deploy the test runner - used to run [agglayer/e2e](https://github.com/agglayer/e2e) tests. |
+
+### `status_checker_params`
+
+| Field | Type   | Default                                                                     | Description                                                                                               |
+| ----- | ------ | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| image | string | ghcr.io/0xpolygon/status-checker:v0.2.8 | Image used to deploy the status checker. |

--- a/src/additional_services/launcher.star
+++ b/src/additional_services/launcher.star
@@ -41,6 +41,7 @@ def launch(
         elif svc == constants.ADDITIONAL_SERVICES.tx_spammer:
             tx_spammer.launch(plan)
         elif svc == constants.ADDITIONAL_SERVICES.status_checker:
-            status_checker.launch(plan, l1_context, l2_context)
+            status_checker_params = polygon_pos_args.get("status_checker_params")
+            status_checker.launch(plan, status_checker_params, l1_context, l2_context)
         else:
             fail("Invalid additional service: %s" % (svc))

--- a/src/additional_services/status_checker.star
+++ b/src/additional_services/status_checker.star
@@ -1,10 +1,9 @@
 util = import_module("./util.star")
 
-STATUS_CHECKER_IMAGE = "ghcr.io/0xpolygon/status-checker:v0.2.8"
-
 
 def launch(
     plan,
+    status_checker_params,
     l1_context,
     l2_context,
 ):
@@ -31,7 +30,7 @@ def launch(
     plan.add_service(
         name="status-checker",
         config=ServiceConfig(
-            image=STATUS_CHECKER_IMAGE,
+            image=status_checker_params.get("image"),
             files={
                 "/etc/status-checker": Directory(
                     artifact_names=[status_checker_config_artifact]

--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -56,6 +56,7 @@ DEFAULT_IMAGES = {
     "pos_contract_deployer_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/pos-contract-deployer:d96d592",
     "pos_el_genesis_builder_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/pos-el-genesis-builder:96a19dd",
     "pos_validator_config_generator_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/pos-validator-config-generator:0.3.0-beta",
+    "status_checker_image": "ghcr.io/0xpolygon/status-checker:v0.2.8",
     "toolbox_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.8",
     # observability
     "prometheus_image": "prom/prometheus:v3.2.1",

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -77,6 +77,9 @@ DEFAULT_POLYGON_POS_PACKAGE_ARGS = {
     "test_runner_params": {
         "image": constants.DEFAULT_IMAGES.get("e2e_image"),
     },
+    "status_checker_params": {
+        "image": constants.DEFAULT_IMAGES.get("status_checker_image"),
+    },
 }
 
 DEFAULT_DEV_ARGS = {
@@ -149,6 +152,14 @@ def _parse_polygon_pos_args(plan, polygon_pos_args):
     test_runner_params = polygon_pos_args.get("test_runner_params", {})
     result["test_runner_params"] = _parse_test_runner_params(
         is_test_runner_deployed, test_runner_params
+    )
+
+    is_status_checker_deployed = (
+        constants.ADDITIONAL_SERVICES.status_checker in result["additional_services"]
+    )
+    status_checker_params = polygon_pos_args.get("status_checker_params", {})
+    result["status_checker_params"] = _parse_status_checker_params(
+        is_status_checker_deployed, status_checker_params
     )
 
     # Sanity check and return the result.
@@ -301,6 +312,29 @@ def _parse_test_runner_params(is_test_runner_deployed, test_runner_params):
 
     # Sort the dict and return the result.
     return _sort_dict_by_values(test_runner_params)
+
+
+def _parse_status_checker_params(is_status_checker_deployed, status_checker_params):
+    # If the status checker is not deployed, return an empty dict.
+    if not is_status_checker_deployed:
+        return {}
+
+    # Create a mutable copy of status_checker_params.
+    if status_checker_params:
+        status_checker_params = dict(status_checker_params)
+    else:
+        # Set default status checker params if not provided.
+        status_checker_params = dict(
+            DEFAULT_POLYGON_POS_PACKAGE_ARGS.get("status_checker_params", {})
+        )
+
+    for k, v in DEFAULT_POLYGON_POS_PACKAGE_ARGS.get(
+        "status_checker_params", {}
+    ).items():
+        status_checker_params.setdefault(k, v)
+
+    # Sort the dict and return the result.
+    return _sort_dict_by_values(status_checker_params)
 
 
 def _sort_dict_by_values(d):

--- a/src/config/sanity_check.star
+++ b/src/config/sanity_check.star
@@ -43,6 +43,9 @@ POLYGON_POS_PARAMS = {
     "test_runner_params": [
         "image",
     ],
+    "status_checker_params": [
+        "image",
+    ],
 }
 
 VALID_PARTICIPANT_KINDS = [
@@ -119,7 +122,7 @@ def sanity_check_polygon_args(plan, input_args):
     cl_environment = network_params.get("cl_environment")
     _validate_cl_environment(cl_environment)
 
-    # Make sure test params are defined only if the test runner is deployed.
+    # Make sure test runner params are defined only if the test runner is deployed.
     additional_services = input_args.get("additional_services", [])
     if constants.ADDITIONAL_SERVICES.test_runner in additional_services:
         _validate_dict(input_args, "test_runner_params")
@@ -128,6 +131,16 @@ def sanity_check_polygon_args(plan, input_args):
         if test_runner_params:
             fail(
                 "`test_runner_params` must be empty when the test runner is not deployed."
+            )
+
+    # Make sure status checker params are defined only if the status checker is deployed.
+    if constants.ADDITIONAL_SERVICES.status_checker in additional_services:
+        _validate_dict(input_args, "status_checker_params")
+    else:
+        status_checker_params = input_args.get("status_checker_params", {})
+        if status_checker_params:
+            fail(
+                "`status_checker_params` must be empty when the status checker is not deployed."
             )
 
     plan.print("Sanity check passed")


### PR DESCRIPTION
Tested locally:

```bash
$ docker pull ghcr.io/0xpolygon/status-checker:v0.2.8
$ docker tag ghcr.io/0xpolygon/status-checker:v0.2.8 status-checker:v0.2.8

$ cat params.yml
polygon_pos_package:
  additional_services:
    - status_checker
  status_checker_params:
    image: status-checker:v0.2.8

$ kurtosis run --enclave test --args-file params.yml .
Starlark code successfully run. No output was returned.

⭐ us on GitHub - https://github.com/kurtosis-tech/kurtosis
INFO[2025-08-27T08:46:27Z] ============================================= 
INFO[2025-08-27T08:46:27Z] ||          Created enclave: test          || 
INFO[2025-08-27T08:46:27Z] ============================================= 
Name:            test
UUID:            6dfb5ae421fc
Status:          RUNNING
Creation Time:   Wed, 27 Aug 2025 08:42:57 UTC
Flags:           

========================================= Files Artifacts =========================================
UUID           Name
f42c2df88a38   1-lighthouse-geth-0-63
b0c7a3aac747   container-proc-manager-script
2d59b566debd   el_cl_genesis_data
e09b19bddec9   final-genesis-timestamp
12f52bb1243d   genesis-el-cl-env-file
34de95b54d08   genesis_validators_root
a67e3d5a27b2   jwt_file
9cbde34cc36e   keymanager_file
8aa1f3d92449   l2-cl-1-heimdall-v2-bor-validator-config
05e516ff100e   l2-cl-1-heimdall-v2-bor-validator-node-config
40ad6b4dfaf7   l2-cl-genesis
689f331fcad2   l2-cl-genesis-builder-config
c44ddfe976f0   l2-cl-genesis-tmp
bd6a4f523616   l2-cl-persistent-peers
03e13082d477   l2-el-1-bor-heimdall-v2-validator-credentials-config
b0993292b4c2   l2-el-1-bor-heimdall-v2-validator-credentials-generator-config
fb3bdd2a09a9   l2-el-1-bor-heimdall-v2-validator-node-config
386b8abae67a   l2-el-genesis
c37f001ccca6   l2-el-genesis-builder-config
0c6388d89018   l2-el-genesis-tmp
c6384d8138be   l2-validator-config-generator-config
7f63ed1f850b   l2-validators-config
b51ab319f15a   matic-contract-addresses
7c0b7a51bae7   matic-contract-l1-addresses
600943dc718a   matic-contracts-l1-deployer-config
3cf20be3361b   matic-contracts-l2-deployer-config
a238304dad3e   prysm-password
419161c366b9   status-checker-checks
b1b5973de460   status-checker-config
5f9f3386add1   validator-ranges

========================================== User Services ==========================================
UUID           Name                                             Ports                                              Status
c7d0623e614d   cl-1-lighthouse-geth                             http: 4000/tcp -> http://127.0.0.1:33100           RUNNING
                                                                metrics: 5054/tcp -> http://127.0.0.1:33101        
                                                                quic-discovery: 9001/udp -> 127.0.0.1:32788        
                                                                tcp-discovery: 9000/tcp -> 127.0.0.1:33102         
                                                                udp-discovery: 9000/udp -> 127.0.0.1:32787         
7633d4b92164   el-1-geth-lighthouse                             engine-rpc: 8551/tcp -> 127.0.0.1:33097            RUNNING
                                                                metrics: 9001/tcp -> http://127.0.0.1:33098        
                                                                rpc: 8545/tcp -> 127.0.0.1:33095                   
                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:33099        
                                                                udp-discovery: 30303/udp -> 127.0.0.1:32786        
                                                                ws: 8546/tcp -> 127.0.0.1:33096                    
d0b100fa4d09   l2-cl-1-heimdall-v2-bor-validator                grpc: 3132/tcp -> grpc://127.0.0.1:33106           RUNNING
                                                                http: 1317/tcp -> http://127.0.0.1:33105           
                                                                metrics: 26660/tcp -> http://127.0.0.1:33109       
                                                                node-listen: 26656/tcp -> http://127.0.0.1:33107   
                                                                rpc: 26657/tcp -> http://127.0.0.1:33108           
fb09f1c21a4e   l2-el-1-bor-heimdall-v2-validator                discovery: 30303/tcp -> http://127.0.0.1:33113     RUNNING
                                                                metrics: 7071/tcp -> http://127.0.0.1:33110        
                                                                rpc: 8545/tcp -> http://127.0.0.1:33111            
                                                                ws: 8546/tcp -> ws://127.0.0.1:33112               
1704594b0b3c   rabbitmq-l2-cl-1-validator                       amqp: 5672/tcp -> amqp://127.0.0.1:33104           RUNNING
76ee09efa0a6   status-checker                                   metrics: 9090/tcp -> http://127.0.0.1:33114        RUNNING
14a7f602de03   validator-key-generation-cl-validator-keystore   <none>                                             RUNNING
25805696b764   vc-1-geth-lighthouse                             metrics: 8080/tcp -> http://127.0.0.1:33103        RUNNING
```