### PR TITLE
ci: increase `run-with-cl-el-genesis` job timeout

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -176,7 +176,7 @@ jobs:
 
   run-with-cl-el-genesis:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Nightly jobs have started failing over the past few days because `run-with-cl-el-genesis` now takes slightly longer than 15 minutes, which exceeds the current timeout.

For reference: https://github.com/0xPolygon/kurtosis-pos/actions/runs/17369007315/job/49300864129