### PR TITLE
chore: bump erigon to `v3.0.16`

### DIFF
--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -50,7 +50,7 @@ DEFAULT_IMAGES = {
     # layer 2
     "l2_cl_heimdall_v2_image": "0xpolygon/heimdall-v2:0.3.0",
     "l2_el_bor_image": "0xpolygon/bor:2.2.10",
-    "l2_el_erigon_image": "erigontech/erigon:v3.0.15",
+    "l2_el_erigon_image": "erigontech/erigon:v3.0.16",
     "l2_cl_db_image": "rabbitmq:4.1.4",
     # utilities
     "e2e_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/e2e:026adc0",


### PR DESCRIPTION
https://github.com/erigontech/erigon/releases/tag/v3.0.16