### PR TITLE
chore: bump bor to `v2.2.11`

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -75,7 +75,7 @@ Default: a single validator.
 | cl_storage_pruning_interval | string | 1m0s                        | Interval between prune routines.                         |
 | cl_indexer_pruning_enabled  | bool   | false                       | Pruning enabling.                                        |
 | el_type                     | string | bor                         | Execution Layer (EL) client type                         |
-| el_image                    | string | 0xpolygon/bor:2.2.10        | Image for the EL client                                  |
+| el_image                    | string | 0xpolygon/bor:2.2.11        | Image for the EL client                                  |
 | el_log_level                | string | info                        | Log level for the EL client                              |
 | count                       | int    | 1                           | Number of nodes to spin up for this participant          |
 

--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -50,7 +50,7 @@ DEFAULT_IMAGES = {
     "l1_cl_image": "ethpandaops/lighthouse:unstable-8ec2640",  # 2025-09-03 - works with the latest version of the ethereum package and the minimal preset
     # layer 2
     "l2_cl_heimdall_v2_image": "0xpolygon/heimdall-v2:0.3.1",
-    "l2_el_bor_image": "0xpolygon/bor:2.2.10",
+    "l2_el_bor_image": "0xpolygon/bor:2.2.11",
     "l2_el_erigon_image": "erigontech/erigon:v3.0.16",
     "l2_cl_db_image": "rabbitmq:4.1.4",
     # utilities


### PR DESCRIPTION
https://github.com/0xPolygon/bor/releases/tag/v2.2.11