### PR TITLE
fix: loadtest script

### DIFF
--- a/static_files/additional_services/tx-spammer/loadtest.sh
+++ b/static_files/additional_services/tx-spammer/loadtest.sh
@@ -31,7 +31,7 @@ handle_error() {
 trap handle_error ERR
 
 # Continuously send load to the rpc.
-eth_amount=$(cast to-unit 1gwei wei)
+amount=$(cast to-unit 1gwei wei)
 while true; do
   log_info "Sending transactions to the rpc"
   polycli loadtest \
@@ -41,7 +41,7 @@ while true; do
     --requests "100" \
     --concurrency "10" \
     --rate-limit "50" \
-    --eth-amount-in-wei "$eth_amount" \
+    --eth-amount-in-wei "$amount" \
     --pretty-logs=false
 
   log_info "Completed batch. Waiting 10 seconds before next batch."

--- a/static_files/additional_services/tx-spammer/loadtest.sh
+++ b/static_files/additional_services/tx-spammer/loadtest.sh
@@ -31,7 +31,7 @@ handle_error() {
 trap handle_error ERR
 
 # Continuously send load to the rpc.
-eth_amount=$(cast to-unit 1gwei ether)
+eth_amount=$(cast to-unit 1gwei wei)
 while true; do
   log_info "Sending transactions to the rpc"
   polycli loadtest \
@@ -41,7 +41,7 @@ while true; do
     --requests "100" \
     --concurrency "10" \
     --rate-limit "50" \
-    --eth-amount "$eth_amount" \
+    --eth-amount-in-wei "$eth_amount" \
     --pretty-logs=false
 
   log_info "Completed batch. Waiting 10 seconds before next batch."


### PR DESCRIPTION
```
{"info": "PRIVATE_KEY: 0x70ab73de2c3b804c6ac38e54a98bc28e9211c9fb564c83707b3c7e875609b285"}
{"info": "RPC_URL: http://172.16.0.12:8545"}
{"info": "Sending transactions to the rpc"}
Error: unknown flag: --eth-amount
Usage:
  polycli loadtest [flags]
  polycli loadtest [command]

Available Commands:
  uniswapv3   Run Uniswapv3-like load test against an Eth/EVm style JSON-RPC endpoint.

Flags:
      --account-funding-amount big.Int         The amount in wei to fund the sending accounts with. Set to 0 to disable account funding (useful for eth-call-only mode or pre-funded accounts).
      --adaptive-backoff-factor float          When using adaptive rate limiting, this flag controls our multiplicative decrease value. (default 2)
      --adaptive-cycle-duration-seconds uint   When using adaptive rate limiting, this flag controls how often we check the queue size and adjust the rates (default 10)
      --adaptive-rate-limit                    Enable AIMD-style congestion control to automatically adjust request rate
      --adaptive-rate-limit-increment uint     When using adaptive rate limiting, this flag controls the size of the additive increases. (default 50)
      --adaptive-target-size uint              When using adaptive rate limiting, this value sets the target queue size. If the queue is smaller than this value, we'll speed up. If the queue is smaller than this value, we'll back off. (default 1000)
      --batch-size uint                        Number of batches to perform at a time for receipt fetching. Default is 999 requests at a time. (default 999)
      --blob-fee-cap uint                      The blob fee cap, or the maximum blob fee per chunk, in Gwei. (default 100000)
      --calldata string                        The hex encoded calldata passed in. The format is function signature + arguments encoded together. This must be paired up with --mode contract-call and --contract-address
      --chain-id uint                          The chain id for the transactions.
  -c, --concurrency int                        Number of requests to perform concurrently. Default is one request at a time. (default 1)
      --contract-address string                The address of the contract that will be used in --mode contract-call. This must be paired up with --mode contract-call and --calldata
      --contract-call-payable                  Use this flag if the function is payable, the value amount passed will be from --eth-amount-in-wei. This must be paired up with --mode contract-call and --contract-address
      --erc20-address string                   The address of a pre-deployed ERC20 contract
      --erc721-address string                  The address of a pre-deployed ERC721 contract
      --eth-amount-in-wei uint                 The amount of ether in wei to send on every transaction
      --eth-call-only                          When using this mode, rather than sending a transaction, we'll just call. This mode is incompatible with adaptive rate limiting, summarization, and a few other features.
      --eth-call-only-latest                   When using call only mode with recall, should we execute on the latest block or on the original block
      --fire-and-forget                        Send transactions and load without waiting for it to be mined.
      --function-arg strings                   The arguments that will be passed to a contract function call. This must be paired up with "--mode contract-call" and "--contract-address". Args can be passed multiple times: "--function-arg 'test' --function-arg 999" or comma separated values "--function-arg "test",9". The ordering of the arguments must match the ordering of the function parameters.
      --function-signature string              The contract's function signature that will be called. The format is '<function name>(<types...>)'. This must be paired up with '--mode contract-call' and '--contract-address'. If the function requires parameters you can pass them with '--function-arg <value>'.
      --gas-limit uint                         In environments where the gas limit can't be computed on the fly, we can specify it manually. This can also be used to avoid eth_estimateGas
      --gas-price uint                         In environments where the gas price can't be determined automatically, we can specify it manually
      --gas-price-multiplier float             A multiplier to increase or decrease the gas price (default 1)
  -h, --help                                   help for loadtest
      --inscription-content string             The inscription content that will be encoded as calldata. This must be paired up with --mode inscription (default "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"TEST\",\"amt\":\"1\"}")
      --keep-funds-after-test                  If set to true, the funded amount will be kept in the sending accounts. Otherwise, the funded amount will be refunded back to the account used to fund the account.
      --legacy                                 Send a legacy transaction instead of an EIP1559 transaction.
      --loadtest-contract-address string       The address of a pre-deployed load test contract
  -m, --mode strings                           The testing mode to use. It can be multiple like: "d,t"
                                               2, erc20 - Send ERC20 tokens
                                               7, erc721 - Mint ERC721 tokens
                                               b, blob - Send blob transactions
                                               cc, contract-call - Make contract calls
                                               d, deploy - Deploy contracts
                                               i, inscription - Send inscription transactions
                                               inc, increment - Increment a counter
                                               r, random - Random modes (does not include the following modes: blob, call, inscription, recall, rpc, uniswapv3)
                                               R, recall - Replay or simulate transactions
                                               rpc - Call random rpc methods
                                               s, store - Store bytes in a dynamic byte array
                                               t, transaction - Send transactions
                                               v3, uniswapv3 - Perform UniswapV3 swaps (default [t])
      --nonce uint                             Use this flag to manually set the starting nonce
      --output-mode string                     Format mode for summary output (json | text) (default "text")
      --pre-fund-sending-accounts              If set to true, the sending accounts will be funded at the start of the execution, otherwise all accounts will be funded when used for the first time.
      --priority-gas-price uint                Specify Gas Tip Price in the case of EIP-1559
      --private-key string                     The hex encoded private key that we'll use to send transactions (default "42b6e34dc21598a807dc19d7784c71b2a7a01f6480dc6f58258f78e539f1a1fa")
      --proxy string                           Use the proxy specified
      --random-recipients                      When doing a transfer test, should we send to random addresses rather than DEADBEEFx5
      --rate-limit float                       An overall limit to the number of requests per second. Give a number less than zero to remove this limit all together (default 4)
      --recall-blocks uint                     The number of blocks that we'll attempt to fetch for recall (default 50)
      --receipt-retry-initial-delay-ms uint    Initial delay in milliseconds for receipt polling retry. Uses exponential backoff with jitter. (default 100)
      --receipt-retry-max uint                 Maximum number of attempts to poll for transaction receipt when --wait-for-receipt is enabled. (default 30)
  -n, --requests int                           Number of requests to perform for the benchmarking session. The default is to just perform a single request which usually leads to non-representative benchmarking results. (default 1)
  -r, --rpc-url string                         The RPC endpoint url (default "http://localhost:8545")
      --seed int                               A seed for generating random values and addresses (default 123456)
      --send-only                              Alias for --fire-and-forget.
      --sending-accounts-count uint            The number of sending accounts to use. This is useful for avoiding pool account queue. (default 1)
      --sending-accounts-file string           The file containing the sending accounts private keys, one per line. This is useful for avoiding pool account queue but also to keep the same sending accounts for different execution cycles.
      --store-data-size uint                   If we're in store mode, this controls how many bytes we'll try to store in our contract (default 1024)
      --summarize                              Should we produce an execution summary after the load test has finished. If you're running a large load test, this can take a long time
  -t, --time-limit int                         Maximum number of seconds to spend for benchmarking. Use this to benchmark within a fixed total amount of time. Per default there is no time limit. (default -1)
      --to-address string                      The address that we're going to send to (default "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF")
      --wait-for-receipt                       If set to true, the load test will wait for the transaction receipt to be mined. If set to false, the load test will not wait for the transaction receipt and will just send the transaction.

Global Flags:
      --config string   config file (default is $HOME/.polygon-cli.yaml)
      --pretty-logs     Should logs be in pretty format or JSON (default true)
  -v, --verbosity int   0 - Silent
                        100 Panic
                        200 Fatal
                        300 Error
                        400 Warning
                        500 Info
                        600 Debug
                        700 Trace (default 500)

Use "polycli loadtest [command] --help" for more information about a command.

{"error": "An error occurred. Continuing execution."}
{"info": "Completed batch. Waiting 10 seconds before next batch."}
```
