### PR TITLE
Increase Genesis Gas Limit

### DIFF
--- a/docs/docs/configuration/reference.md
+++ b/docs/docs/configuration/reference.md
@@ -53,7 +53,7 @@ polygon_pos_package:
       count: 2
   network_params:
     el_block_interval_seconds: 2
-    el_gas_limit: 10_000_000
+    el_gas_limit: 45_000_000
   additional_services:
     - observability
 ```
@@ -108,7 +108,7 @@ You can check the admin private key and mnemonic default values at `src/config/i
 | el_block_interval_seconds             | int    | 1                      | Seconds per block on the EL chain                                  |
 | el_sprint_duration                    | int    | 16                     | Duration of an EL sprint (blocks)                                  |
 | el_span_duration                      | int    | 128                    | Duration of an EL span (blocks).                                   |
-| el_gas_limit                          | int    | 10_000_000             | EL gas limit                                                       |
+| el_gas_limit                          | int    | 45_000_000             | EL gas limit                                                       |
 
 ### `additional_services`
 

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -98,7 +98,7 @@ DEFAULT_POLYGON_POS_PACKAGE_ARGS = {
         "el_block_interval_seconds": 1,
         "el_sprint_duration": 16,
         "el_span_duration": 128,
-        "el_gas_limit": math.pow(10, 7),
+        "el_gas_limit": 45000000,
     },
     "additional_services": [
         constants.ADDITIONAL_SERVICES.test_runner,


### PR DESCRIPTION
We already set `45_000_000` as our goal gas limit on the [miner](https://github.com/0xPolygon/kurtosis-pos/blob/de39cf6168f9220f24edcb5248f9633c8e583663/static_files/el/bor/config.toml#L30). But since the genesis gas limit is currently set to `10_000_000`, it need to slowly progress until reaches the goal target of 45Mi.

Reference:

https://ethereum.org/developers/docs/blocks

> The block gas limit can be adjusted upwards or downwards by a factor of 1/1024 from the previous block's gas limit. As a result, validators can change the block gas limit through consensus.