### PR TITLE
fix: revert erigon to `v3.0.18`

### DIFF
--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -55,7 +55,7 @@ DEFAULT_IMAGES = {
     # layer 2
     "l2_cl_heimdall_v2_image": "0xpolygon/heimdall-v2:0.4.2",
     "l2_el_bor_image": "0xpolygon/bor:2.3.4",
-    "l2_el_erigon_image": "0xpolygon/erigon:v3.1.3",
+    "l2_el_erigon_image": "0xpolygon/erigon:v3.0.18",
     "l2_cl_db_image": "rabbitmq:4.1.4",
     # utilities
     "e2e_image": "ghcr.io/agglayer/e2e:16fc898",


### PR DESCRIPTION
Nightly jobs have been failing because the new version of erigon, `3.1.x`, does not process state syncs.

For reference: https://github.com/0xPolygon/kurtosis-pos/actions/runs/18739049809/job/53451469942