### PR TITLE
Add parallel-stateless-import config

### DIFF
--- a/static_files/el/bor/config.toml
+++ b/static_files/el/bor/config.toml
@@ -10,6 +10,7 @@ verbosity = {{.log_level_to_int}}
     fastforwardthreshold=30
     {{if .sync_with_witness}}
     syncwithwitnesses = true
+    parallel-stateless-import = true
     {{end}}
 
     {{if .produce_witness}}


### PR DESCRIPTION
This PR adds the `parallel-stateless-import` option to enable parallel block import, which was added in 0xPolygon/bor#1662