### PR TITLE
feat: multiple heimdall-v2 fallback url for bor

### DIFF
--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -55,7 +55,7 @@ IMAGES = {
     "l1_anvil_image": "ghcr.io/foundry-rs/foundry:v1.6.0-rc1",
     # layer 2
     "l2_cl_heimdall_v2_image": "0xpolygon/heimdall-v2:0.6.0",
-    "l2_el_bor_image": "0xpolygon/bor:2.5.9",
+    "l2_el_bor_image": "0xpolygon/bor:2.6.3-beta",
     "l2_el_erigon_image": "0xpolygon/erigon:v3.3.7",
     "l2_cl_queue_image": "rabbitmq:4.2.4",
     # utilities

--- a/src/el/bor/launcher.star
+++ b/src/el/bor/launcher.star
@@ -93,27 +93,33 @@ def launch(
         name=el_node_name,
         config=ServiceConfig(
             image=participant.get("el_image"),
-            # All port checks are disabled, see the comment above.
+            # Port readiness checks are disabled because bor may take a long time
+            # to start while waiting for heimdall to sync.
             ports={
                 shared.RPC_PORT_ID: PortSpec(
                     number=shared.RPC_PORT_NUMBER,
                     application_protocol="http",
+                    wait=None,
                 ),
                 shared.WS_PORT_ID: PortSpec(
                     number=shared.WS_PORT_NUMBER,
                     application_protocol="ws",
+                    wait=None,
                 ),
                 shared.DISCOVERY_PORT_ID: PortSpec(
                     number=shared.DISCOVERY_PORT_NUMBER,
                     application_protocol="http",
+                    wait=None,
                 ),
                 shared.METRICS_PORT_ID: PortSpec(
                     number=shared.METRICS_PORT_NUMBER,
                     application_protocol="http",
+                    wait=None,
                 ),
                 shared.PPROF_PORT_ID: PortSpec(
                     number=shared.PPROF_PORT_NUMBER,
                     application_protocol="http",
+                    wait=None,
                 ),
             },
             files={

--- a/src/el_cl_launcher.star
+++ b/src/el_cl_launcher.star
@@ -48,7 +48,7 @@ def launch(
     participant_index = 0
     validator_index = 0
     all_participants = []
-    first_cl_context = None
+    all_cl_contexts = []
     for _, participant in enumerate(participants):
         is_validator = participant.get("kind") == constants.PARTICIPANT_KIND.validator
         for _ in range(participant.get("count")):
@@ -73,18 +73,31 @@ def launch(
                     l1_rpc_url,
                     container_proc_manager_artifact,
                 )
-                if not first_cl_context:
-                    first_cl_context = cl_context
+                all_cl_contexts.append(cl_context)
 
             # Retrieve the correct CL api url.
+            # Validators use their own CL node. Non-validators get
+            # comma-separated heimdall URLs for failover (bor), or a
+            # single URL via round-robin (erigon, which doesn't support
+            # multiple heimdall URLs).
             cl_api_url = None
             cl_ws_rpc_url = None
             if cl_context:
                 cl_api_url = cl_context.api_url
                 cl_ws_rpc_url = cl_context.ws_rpc_url
-            elif first_cl_context:
-                cl_api_url = first_cl_context.api_url
-                cl_ws_rpc_url = first_cl_context.ws_rpc_url
+            elif len(all_cl_contexts) > 0:
+                el_type = participant.get("el_type")
+                if el_type == constants.EL_TYPE.bor:
+                    cl_api_url = ",".join([ctx.api_url for ctx in all_cl_contexts])
+                    cl_ws_rpc_url = ",".join(
+                        [ctx.ws_rpc_url for ctx in all_cl_contexts]
+                    )
+                else:
+                    assigned_cl_context = all_cl_contexts[
+                        participant_index % len(all_cl_contexts)
+                    ]
+                    cl_api_url = assigned_cl_context.api_url
+                    cl_ws_rpc_url = assigned_cl_context.ws_rpc_url
             else:
                 fail("No CL node deployed yet...")
 
@@ -106,12 +119,19 @@ def launch(
             )
 
             # Add the node to the all_participants array.
+            # Non-validators reference a validator's CL context (round-robin)
+            # for metadata such as startup wait checks.
+            effective_cl_context = (
+                cl_context
+                if cl_context
+                else all_cl_contexts[participant_index % len(all_cl_contexts)]
+            )
             all_participants.append(
                 participant_module.new_participant(
                     kind=participant.get("kind"),
                     cl_type=participant.get("cl_type"),
                     el_type=participant.get("el_type"),
-                    cl_context=cl_context or first_cl_context,
+                    cl_context=effective_cl_context,
                     el_context=el_context,
                 )
             )
@@ -134,7 +154,7 @@ def launch(
 
     # Wait for the devnet to reach a certain state.
     # The first producer should have committed a span.
-    wait.wait_for_l2_startup(plan, first_cl_context.api_url)
+    wait.wait_for_l2_startup(plan, all_cl_contexts[0].api_url)
 
     # Return the L2 context.
     return struct(

--- a/static_files/el/bor/config.toml
+++ b/static_files/el/bor/config.toml
@@ -66,7 +66,7 @@ ethstats = "{{.node_name}}:{{.ethstats_server_secret}}@ethstats-server:{{.ethsta
     static-nodes = {{.static_nodes}}
 
 [heimdall]
-  # URL of the heimdall server (default: http://localhost:1317)
+  # URL of the heimdall server (comma-separated for failover: "url1,url2,url3") (default: http://localhost:1317)
   url = "{{.cl_api_url}}"
   # Address of the heimdall ws subscription server (default: "")
   ws-address = "{{.cl_ws_rpc_url}}"


### PR DESCRIPTION
# Description

- Add multiple heimdall-v2 [fallback url ](https://github.com/0xPolygon/bor/blob/develop/docs/cli/default_config.toml#L113-L114)for Bor
    - This seems to be only available on the [current develop](https://github.com/0xPolygon/bor/commit/ee7a94b6820b7316f2457f7591266720ff9a76e6) branch
- For Erigon, we'll rely on a round-robin approach instead to minimize reliance on a single validator
    - Erigon still connects to a single heimdall-v2 url only