### PR TITLE
fix: e2e tests

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -5,7 +5,7 @@ inputs:
   agglayer_e2e_tag:
     description: The git tag, branch, or commit hash of agglayer/e2e
     required: false
-    default: 6b806a06083ea4123fbfc124fab8c4ace3edbe1e
+    default: 6795c653919e49737a982773e0a3aac67f74d887
   polygon_cli_version:
     description: The release version of polygon-cli
     required: false

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -5,7 +5,7 @@ inputs:
   agglayer_e2e_tag:
     description: The git tag, branch, or commit hash of agglayer/e2e
     required: false
-    default: 6795c653919e49737a982773e0a3aac67f74d887
+    default: f1ca97e120df6d7425b757a3d25e5cd8e7c5ce2a
   polygon_cli_version:
     description: The release version of polygon-cli
     required: false

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -5,7 +5,7 @@ inputs:
   agglayer_e2e_tag:
     description: The git tag, branch, or commit hash of agglayer/e2e
     required: false
-    default: 1831cd486ed80aa300943f23900491bb949c77a2
+    default: 6b806a06083ea4123fbfc124fab8c4ace3edbe1e
   polygon_cli_version:
     description: The release version of polygon-cli
     required: false

--- a/.github/configs/nightly/e2e-tests.yml
+++ b/.github/configs/nightly/e2e-tests.yml
@@ -4,8 +4,3 @@ polygon_pos_package:
       el_type: bor
       cl_type: heimdall-v2
       count: 2
-  network_params:
-    # consensus layer
-    cl_chain_id: heimdall-4928
-    # execution layer
-    el_chain_id: 4928

--- a/.github/configs/nightly/e2e-tests.yml
+++ b/.github/configs/nightly/e2e-tests.yml
@@ -1,0 +1,11 @@
+polygon_pos_package:
+  participants:
+    - kind: validator
+      el_type: bor
+      cl_type: heimdall-v2
+      count: 2
+  network_params:
+    # consensus layer
+    cl_chain_id: heimdall-4928
+    # execution layer
+    el_chain_id: 4928

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,10 +43,6 @@ jobs:
 
       - uses: ./.github/actions/test-state-sync
 
-      - uses: ./.github/actions/run-e2e-tests
-        # Only run the full suite of e2e tests in nightly runs or when manually triggered, to avoid excessive runtime in regular PR runs.
-        if: ${{ contains(github.event_name, 'schedule') || contains(github.event_name, 'workflow_dispatch') }}
-
       - uses: ./.github/actions/cleanup
         if: always()
 
@@ -60,8 +56,8 @@ jobs:
       - id: set-matrix
         run: |
           if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Nightly mode: include all configs except cl-el-genesis and external-l1
-            file_paths=$(ls -R ./.github/configs/{*,*/*,*/*/*}.yml | grep -Ev "cl-el-genesis|external-l1")
+            # Nightly mode: include all configs except cl-el-genesis, external-l1, and e2e-tests (handled by run-e2e-tests job)
+            file_paths=$(ls -R ./.github/configs/{*,*/*,*/*/*}.yml | grep -Ev "cl-el-genesis|external-l1|e2e-tests")
           else
             # Regular mode: exclude nightly configs
             file_paths=$(ls -R ./.github/configs/{*,*/*}.yml | grep -Ev "nightly")
@@ -120,6 +116,32 @@ jobs:
           args_filename: ${{ matrix.file.name }}
           # Cache is only saved by main branch runs to avoid excessive storage use
           save_cache: ${{ github.ref == 'refs/heads/main' && matrix.file.name == 'heimdall-v2-mix' }}
+
+  run-e2e-tests:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup
+        with:
+          docker_username: ${{ secrets.DOCKER_USERNAME }}
+          docker_token: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Deploy devnet
+        run: |
+          set -o pipefail
+          kurtosis run --enclave=${{ env.ENCLAVE_NAME }} --verbosity detailed --args-file=./.github/configs/nightly/e2e-tests.yml . 2>&1 | tee run.log
+
+      - uses: ./.github/actions/monitor
+
+      - uses: ./.github/actions/run-e2e-tests
+
+      - uses: ./.github/actions/cleanup
+        if: always()
+        with:
+          args_filename: e2e-tests
 
   run-with-external-l1:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -235,6 +257,7 @@ jobs:
     needs:
       - run-without-args
       - run-with-args
+      - run-e2e-tests
       - run-with-external-l1
       - run-with-cl-el-genesis
     steps:


### PR DESCRIPTION
## Summary

- Run the full plasma bridge/withdraw and validator e2e test suite in a dedicated nightly CI job (2-validator devnet)
- Bump agglayer e2e tag to include the last fixes (https://github.com/agglayer/e2e/pull/257)

## Test plan

- [x] All 8 validator tests pass on a 2-node devnet (local)
- [x] All 5 Plasma bridge tests pass on a 2-node devnet (local)
- [x] All 4 Plasma bridge withdraw tests pass on a 2-node devnet (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
