### PR TITLE
chore: revert pos-contract bump

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -79,7 +79,7 @@ jobs:
         id: push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
-          context: docker
+          context: .
           file: docker/pos-contract-deployer.Dockerfile
           build-args: |
             POS_CONTRACTS_BRANCH=${{ env.POS_CONTRACTS_BRANCH }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -30,7 +30,7 @@ env:
   # pos-contract-deployer settings
   POS_CONTRACTS_IMAGE_NAME: 0xPolygon/pos-contract-deployer
   POS_CONTRACTS_BRANCH: anvil-pos
-  POS_CONTRACTS_COMMIT_SHA: "bc28cfd8"
+  POS_CONTRACTS_COMMIT_SHA: d96d5929 # 2025-08-01
 
   # pos-el-genesis-builder settings
   EL_GENESIS_BUILDER_IMAGE_NAME: 0xPolygon/pos-el-genesis-builder

--- a/docker/pos-contract-deployer.Dockerfile
+++ b/docker/pos-contract-deployer.Dockerfile
@@ -3,7 +3,7 @@ LABEL description="Polygon PoS contracts deployment image"
 LABEL author="devtools@polygon.technology"
 
 ARG POS_CONTRACTS_BRANCH="anvil-pos"
-ARG POS_CONTRACTS_TAG_OR_COMMIT_SHA="bc28cfd8"
+ARG POS_CONTRACTS_TAG_OR_COMMIT_SHA="d96d5929"
 
 ENV FOUNDRY_VERSION="stable"
 ENV EL_CHAIN_ID="4927"
@@ -22,9 +22,10 @@ RUN apt-get update \
   && bash /root/.foundry/bin/foundryup --install ${FOUNDRY_VERSION} \
   && cp /root/.foundry/bin/* /usr/local/bin \
   && rm /tmp/foundry-install.sh \
-  # Prepare pos contracts (shallow clone with submodules)
-  && git clone --branch ${POS_CONTRACTS_BRANCH} --depth 1 --recurse-submodules --shallow-submodules https://github.com/0xPolygon/pos-contracts . \
+  # Prepare pos contracts (full branch clone so any commit SHA is reachable, submodules shallow).
+  && git clone --branch ${POS_CONTRACTS_BRANCH} https://github.com/0xPolygon/pos-contracts . \
   && git checkout ${POS_CONTRACTS_TAG_OR_COMMIT_SHA} \
+  && git submodule update --init --recursive --depth 1 \
   && find . -name .git -exec rm -rf {} + 2>/dev/null || true \
   # Remove [etherscan] section from foundry.toml
   && sed -i '/^\[etherscan\]/,/^$/d' foundry.toml \
@@ -36,3 +37,8 @@ RUN apt-get update \
   # Clean up to reduce image size while keeping dependencies needed for forge script
   && npm prune --production \
   && npm cache clean --force
+
+# Add devnet-only deployment scripts (not part of upstream pos-contracts at this revision).
+COPY static_files/contracts/deployPolAndMigration.s.sol scripts/deployment-scripts/deployPolAndMigration.s.sol
+COPY static_files/contracts/deployBurnOnlyPredicates.s.sol scripts/deployment-scripts/deployBurnOnlyPredicates.s.sol
+RUN forge build

--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -59,7 +59,7 @@ IMAGES = {
     "l2_el_erigon_image": "0xpolygon/erigon:v3.5.0",
     "l2_cl_queue_image": "rabbitmq:4.2.5",
     # utilities
-    "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:bc28cfd8",
+    "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:d96d5929",
     "pos_el_genesis_builder_image": "ghcr.io/0xpolygon/pos-el-genesis-builder:96a19dd",
     "pos_validator_config_generator_image": "ghcr.io/0xpolygon/pos-validator-config-generator:0.6.0",
     "toolbox_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12",

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -334,7 +334,8 @@ def _parse_participants(participants, log_level, log_format):
             p.setdefault(k, v)
 
         # Fill in any missing fields with default values for bor participants.
-        if el_type == constants.EL_TYPE.bor:
+        # Re-read el_type from p so the defaulted value (set just above) is also honoured.
+        if p.get("el_type") == constants.EL_TYPE.bor:
             for k, v in POLYGON_POS_EL_BOR_PARTICIPANT.items():
                 p.setdefault(k, v)
 

--- a/static_files/contracts/deploy-l1-contracts.sh
+++ b/static_files/contracts/deploy-l1-contracts.sh
@@ -57,6 +57,13 @@ forge script -vvvv --rpc-url "${L1_RPC_URL}" --broadcast \
 forge script -vvvv --rpc-url "${L1_RPC_URL}" --broadcast \
   scripts/deployment-scripts/initializeState.s.sol:InitializeStateScript
 
+# Swap ERC20/ERC721 predicates for the BurnOnly variants (typed-tx support).
+# pos-contracts at d96d5929 deploys ERC20Predicate + ERC721Predicate, whose
+# startExitWithBurntTokens does not handle EIP-1559 receipts. Mainnet registered
+# the *BurnOnly variants, so do the same here to stay faithful to mainnet.
+forge script -vvvv --rpc-url "${L1_RPC_URL}" --broadcast \
+  scripts/deployment-scripts/deployBurnOnlyPredicates.s.sol:DeployBurnOnlyPredicatesScript
+
 mkdir -p /opt/contracts
 cp contractAddresses.json /opt/contracts
 
@@ -138,4 +145,85 @@ if [[ -s "${VALIDATORS_CONFIG_FILE}" ]]; then
   cat "${VALIDATORS_CONFIG_FILE}"
 else
   echo "Error: ${VALIDATORS_CONFIG_FILE} does not exist or is empty."
+fi
+
+# Deploy POL token and PolygonMigration, then wire them into the system.
+# Validators staked MATIC above (before initializePOL); initializePOL converts that MATIC to POL.
+echo "Deploying POL token and PolygonMigration..."
+forge script -vvvv --rpc-url "${L1_RPC_URL}" --broadcast \
+  scripts/deployment-scripts/deployPolAndMigration.s.sol:DeployPolAndMigrationScript
+
+# Parse deployed addresses from the broadcast JSON.
+l1_chain_id=$(cast chain-id --rpc-url "${L1_RPC_URL}")
+broadcast_file="/opt/pos-contracts/broadcast/deployPolAndMigration.s.sol/${l1_chain_id}/run-latest.json"
+pol_token=$(jq -r '.transactions[] | select(.contractName == "ERC20Permit") | .contractAddress' "${broadcast_file}" | head -1)
+migration=$(jq -r '.transactions[] | select(.contractName == "PolygonMigration") | .contractAddress' "${broadcast_file}" | head -1)
+echo "POL token: ${pol_token}"
+echo "PolygonMigration: ${migration}"
+
+if [[ -z "${pol_token}" || "${pol_token}" == "null" ]]; then
+  echo "Error: failed to parse POL token address from broadcast file."
+  exit 1
+fi
+if [[ -z "${migration}" || "${migration}" == "null" ]]; then
+  echo "Error: failed to parse PolygonMigration address from broadcast file."
+  exit 1
+fi
+
+# Merge the new addresses into contractAddresses.json.
+jq --arg pol "${pol_token}" --arg migration "${migration}" \
+  '.root.tokens.PolToken = $pol | .root.tokens.PolygonMigration = $migration' \
+  contractAddresses.json > contractAddresses.json.tmp
+mv contractAddresses.json.tmp contractAddresses.json
+
+# POL migration — sequence mirrors mainnet's UpgradeStake_DepositManager_Mainnet batch
+# (pos-contracts scripts/deployers/pol-upgrade/...). Steps 2/8 (impl upgrades) are
+# skipped because d96d5929 already ships the POL-aware StakeManager and DepositManager.
+matic_token=$(jq -r '.root.tokens.MaticToken' "${CONTRACT_ADDRESSES_FILE}")
+registry_proxy_address=$(jq -r '.root.Registry' "${CONTRACT_ADDRESSES_FILE}")
+deposit_manager_proxy_address=$(jq -r '.root.DepositManagerProxy' "${CONTRACT_ADDRESSES_FILE}")
+native_gas_token="0x0000000000000000000000000000000000001010"
+
+# Mainnet step 3: StakeManager.initializePOL — converts StakeManager's MATIC stakes to POL.
+echo "Calling StakeManager.initializePOL..."
+calldata=$(cast calldata "initializePOL(address,address)" "${pol_token}" "${migration}")
+cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" \
+  "${governance_proxy_address}" "update(address,bytes)" "${stake_manager_proxy_address}" "${calldata}"
+
+# Mainnet steps 4/5/6: register pol, matic, polygonMigration in the contract map.
+echo "Registering pol, matic, polygonMigration in Registry..."
+for pair in "pol:${pol_token}" "matic:${matic_token}" "polygonMigration:${migration}"; do
+  key="${pair%%:*}"
+  addr="${pair##*:}"
+  key_hash=$(cast keccak "${key}")
+  calldata=$(cast calldata "updateContractMap(bytes32,address)" "${key_hash}" "${addr}")
+  cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" \
+    "${governance_proxy_address}" "update(address,bytes)" "${registry_proxy_address}" "${calldata}"
+  echo "Registered ${key} -> ${addr}"
+done
+
+# Mainnet step 7: map POL to the PoS native gas token (0x...1010).
+# Sets rootToChildToken[POL] = native and — as a side effect — childToRootToken[native] = POL.
+# The reverse overwrite is intentional on mainnet; the ERC20Predicate reads the L1 rootToken
+# from the L2 Withdraw event topic, not from childToRootToken, so MATIC withdraws still work.
+echo "Mapping POL -> native gas token..."
+calldata=$(cast calldata "mapToken(address,address,bool)" "${pol_token}" "${native_gas_token}" false)
+cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" \
+  "${governance_proxy_address}" "update(address,bytes)" "${registry_proxy_address}" "${calldata}"
+
+# Mainnet step 9: drain DepositManager MATIC into POL. No-op on a fresh devnet
+# (DepositManager holds 0 MATIC until users bridge), kept for mainnet parity.
+echo "Calling DepositManager.migrateMatic..."
+calldata=$(cast calldata "migrateMatic()")
+cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" \
+  "${governance_proxy_address}" "update(address,bytes)" "${deposit_manager_proxy_address}" "${calldata}"
+
+# Sync the updated contractAddresses.json to /opt/contracts for the kurtosis artifact.
+echo "Syncing updated contract addresses to /opt/contracts/..."
+cp contractAddresses.json /opt/contracts/contractAddresses.json
+
+if [[ -s "${CONTRACT_ADDRESSES_FILE}" ]]; then
+  echo "Final contract addresses:"
+  cat "${CONTRACT_ADDRESSES_FILE}"
+  echo
 fi

--- a/static_files/contracts/deployBurnOnlyPredicates.s.sol
+++ b/static_files/contracts/deployBurnOnlyPredicates.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {Script, stdJson, console} from "forge-std/Script.sol";
+
+// Swaps ERC20Predicate / ERC721Predicate (old, no typed-tx support) for their
+// *BurnOnly variants (which use ExitPayloadReader and handle EIP-1559 / typed-tx
+// receipts). This mirrors mainnet, which registered the burn-only predicates.
+// Without this swap, startExitWithBurntTokens reverts silently on EIP-1559 burns
+// because the old predicates call toList() on the raw typed-tx receipt bytes.
+contract DeployBurnOnlyPredicatesScript is Script {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        string memory path = "contractAddresses.json";
+        string memory json = vm.readFile(path);
+        address withdrawManagerProxy = vm.parseJsonAddress(json, ".root.WithdrawManagerProxy");
+        address depositManagerProxy = vm.parseJsonAddress(json, ".root.DepositManagerProxy");
+        address registry = vm.parseJsonAddress(json, ".root.Registry");
+        address governance = vm.parseJsonAddress(json, ".root.GovernanceProxy");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        address erc20Predicate = deployCode(
+            "out/ERC20PredicateBurnOnly.sol/ERC20PredicateBurnOnly.json",
+            abi.encode(withdrawManagerProxy, depositManagerProxy)
+        );
+        console.log("ERC20PredicateBurnOnly:", erc20Predicate);
+
+        address erc721Predicate = deployCode(
+            "out/ERC721PredicateBurnOnly.sol/ERC721PredicateBurnOnly.json",
+            abi.encode(withdrawManagerProxy, depositManagerProxy)
+        );
+        console.log("ERC721PredicateBurnOnly:", erc721Predicate);
+
+        // Register via governance.update. addErc20Predicate / addErc721Predicate
+        // overwrite the singleton and add the new address to Registry.predicates;
+        // the old predicate entries in that mapping are harmless (nothing calls them).
+        (bool okErc20,) = governance.call(
+            abi.encodeWithSignature(
+                "update(address,bytes)",
+                registry,
+                abi.encodeWithSignature("addErc20Predicate(address)", erc20Predicate)
+            )
+        );
+        require(okErc20, "addErc20Predicate failed");
+
+        (bool okErc721,) = governance.call(
+            abi.encodeWithSignature(
+                "update(address,bytes)",
+                registry,
+                abi.encodeWithSignature("addErc721Predicate(address)", erc721Predicate)
+            )
+        );
+        require(okErc721, "addErc721Predicate failed");
+
+        vm.stopBroadcast();
+
+        vm.writeJson(vm.toString(erc20Predicate), path, ".root.predicates.ERC20Predicate");
+        vm.writeJson(vm.toString(erc721Predicate), path, ".root.predicates.ERC721Predicate");
+    }
+}

--- a/static_files/contracts/deployPolAndMigration.s.sol
+++ b/static_files/contracts/deployPolAndMigration.s.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {Script, console} from "forge-std/Script.sol";
+
+// Minimal interface for the ERC20Permit/TestToken deployed as POL.
+interface IERC20Like {
+    function transfer(address to, uint256 amount) external returns (bool);
+    function totalSupply() external view returns (uint256);
+}
+
+// Deploys ERC20Permit as POL token and PolygonMigration, then funds the migration contract.
+// All contracts already exist in pos-contracts; deployed from compiled artifacts via deployCode.
+// Keeps 10M POL for the deployer so bridge tests can deposit POL from L1.
+contract DeployPolAndMigrationScript is Script {
+    uint256 constant DEPLOYER_POL_RESERVE = 10_000_000 * 1e18;
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+
+        string memory path = "contractAddresses.json";
+        string memory json = vm.readFile(path);
+        address maticToken = vm.parseJsonAddress(json, ".root.tokens.MaticToken");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // Deploy POL token (ERC20Permit extends TestToken which mints 10B to msg.sender).
+        address polToken = deployCode(
+            "out/ERC20Permit.sol/ERC20Permit.json",
+            abi.encode("POL", "POL", "1")
+        );
+        console.log("POL token deployed at:", polToken);
+
+        // Deploy PolygonMigration (legacy=MATIC, staking=POL).
+        address migration = deployCode(
+            "out/PolygonMigration.sol/PolygonMigration.json",
+            abi.encode(maticToken, polToken)
+        );
+        console.log("PolygonMigration deployed at:", migration);
+
+        // Fund migration with all but 10M POL — migration needs POL to exchange MATIC 1:1.
+        uint256 migrationPol = IERC20Like(polToken).totalSupply() - DEPLOYER_POL_RESERVE;
+        IERC20Like(polToken).transfer(migration, migrationPol);
+        console.log("Migration funded with POL:", migrationPol);
+
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
## Description

- Revert to https://github.com/0xPolygon/pos-contracts/tree/d96d5929037d77f10af24404bbd02d3dc794decd
- Add script to perform MATIC -> POL migration
- Deploy the correct ERC20/721 predicates to allow withdrawals
- Also fix a small bug in the input parser

## Test

- Plasma bridge and withdraw tests
- Validator tests
