### PR TITLE
fix: tolerate transient RPC errors in parallel block monitors

### DIFF
--- a/.github/actions/monitor/blocks-bor.sh
+++ b/.github/actions/monitor/blocks-bor.sh
@@ -31,8 +31,11 @@ monitor_rpc() {
   for step in $(seq 1 "${num_steps}"); do
     log_info "Check ${step}/${num_steps} for ${rpc_name}"
 
-    LATEST_BLOCK=$(cast bn --rpc-url "${rpc_url}")
-    FINALIZED_BLOCK=$(cast bn finalized --rpc-url "${rpc_url}")
+    # Tolerate transient RPC errors (e.g. "finalized block not found" before the
+    # chain has reached the finality threshold) — treat as 0 so the loop retries
+    # instead of being killed by set -e.
+    LATEST_BLOCK=$(cast bn --rpc-url "${rpc_url}" 2>/dev/null || echo 0)
+    FINALIZED_BLOCK=$(cast bn finalized --rpc-url "${rpc_url}" 2>/dev/null || echo 0)
     log_info "Got block height: latest=${LATEST_BLOCK}, finalized=${FINALIZED_BLOCK}"
     if [[ "${LATEST_BLOCK}" -ge "${target}" && "${FINALIZED_BLOCK}" -ge "${target}" ]]; then
       break
@@ -40,7 +43,7 @@ monitor_rpc() {
 
     # Send a transaction to stimulate progress
     local gas_price
-    gas_price=$(cast gas-price --rpc-url "$rpc_url")
+    gas_price=$(cast gas-price --rpc-url "$rpc_url" 2>/dev/null || echo 0)
     gas_price=$(bc -l <<< "$gas_price * $gas_price_factor" | sed 's/\..*//')
 
     log_info "Sending a test transaction"
@@ -124,15 +127,17 @@ done
 
 # Wait for all background jobs and collect exit codes
 failed=0
-for pid in "${pids[@]}"; do
-  if ! wait "${pid}"; then
+declare -a failed_rpcs=()
+for i in "${!pids[@]}"; do
+  if ! wait "${pids[$i]}"; then
     failed=1
+    failed_rpcs+=("${rpc_array[$i]%%--*}")
   fi
 done
 
 # Check if any RPC failed
 if [[ "${failed}" -eq 1 ]]; then
-  log_error "One or more RPCs failed to reach target block height" "target=${target}"
+  log_error "RPCs failed to reach target block height" "target=${target}" "rpcs=${failed_rpcs[*]}"
   exit 1
 fi
 

--- a/.github/actions/monitor/blocks-heimdall.sh
+++ b/.github/actions/monitor/blocks-heimdall.sh
@@ -29,7 +29,10 @@ monitor_cl() {
   for step in $(seq 1 "${num_steps}"); do
     log_info "Check ${step}/${num_steps} for ${cl_name}"
 
-    LATEST_BLOCK=$(curl -s "${rpc_url}/status" | jq --raw-output '.result.sync_info.latest_block_height')
+    # Tolerate transient curl/jq failures — treat as 0 so the loop retries
+    # instead of being killed by set -e (and pipefail).
+    LATEST_BLOCK=$(curl -s "${rpc_url}/status" 2>/dev/null | jq --raw-output '.result.sync_info.latest_block_height // 0' 2>/dev/null || echo 0)
+    [[ -z "${LATEST_BLOCK}" || "${LATEST_BLOCK}" == "null" ]] && LATEST_BLOCK=0
     log_info "Got block height: ${LATEST_BLOCK}"
 
     if [[ "${LATEST_BLOCK}" -ge "${target}" ]]; then
@@ -97,15 +100,17 @@ done
 
 # Wait for all background jobs and collect exit codes
 failed=0
-for pid in "${pids[@]}"; do
-  if ! wait "${pid}"; then
+declare -a failed_cls=()
+for i in "${!pids[@]}"; do
+  if ! wait "${pids[$i]}"; then
     failed=1
+    failed_cls+=("${cl_array[$i]%%--*}")
   fi
 done
 
 # Check if any CL node failed
 if [[ "${failed}" -eq 1 ]]; then
-  log_error "One or more CL nodes failed to reach target block height" "target=${target}"
+  log_error "CL nodes failed to reach target block height" "target=${target}" "cls=${failed_cls[*]}"
   exit 1
 fi
 


### PR DESCRIPTION
Under `set -euo pipefail`, a non-zero exit from cast/curl inside the parallel monitor_rpc/monitor_cl subshells silently killed the background job mid-iteration — most often triggered by "finalized block not found" returned by bor before the chain reached the finality threshold. The parent's wait then reported a generic "one or more RPCs failed", with no indication of which RPC or why.

Capture transient failures with `2>/dev/null || echo 0` so the loop retries instead, and surface the specific failed RPC/CL names in the final error message.