### PR TITLE
chore: bump el genesis delay floor from 20s to 45s

### DIFF
--- a/src/el/genesis.star
+++ b/src/el/genesis.star
@@ -117,10 +117,13 @@ def generate(
 # Returns how many seconds to push the genesis timestamp into the future so all
 # validators are ready to mine when bor wakes up. Numbers chosen by hand:
 #   - 0 for single-node devnet: nothing to peer with, no race.
-#   - 20s base: spread between two parallel container starts.
+#   - 45s base: spread between two parallel container starts. The previous 20s
+#     floor was too tight on GitHub Actions runners — the hv2-bor and hv2-mix
+#     stability configs (n=2) saw 30–43% deploy failures from nodes mining
+#     before peering and forking at genesis.
 #   - +5s per extra validator: docker daemon / disk / image-pull contention.
 #   - 180s cap: beyond that, image-pull bandwidth dominates and more delay does not help.
 def _compute_delay(n):
     if n <= 1:
         return 0
-    return min(180, 20 + 5 * (n - 2))
+    return min(180, 45 + 5 * (n - 2))


### PR DESCRIPTION
The 20s floor introduced in #540 was too tight on GHA runners. In nightly stability run [25094880141](https://github.com/0xPolygon/kurtosis-pos/actions/runs/25094880141), the heimdall-v2-bor and heimdall-v2-mix configs (n=2 validators) saw 30–43% deploy failures caused by bor nodes mining before peering and forking at genesis. The forks surfaced as Heimdall returning HTTP 500 on /bor/spans/1 and gRPC code 18 (RESOURCE_EXHAUSTED) on span broadcasts, eventually tripping the l2-startup-monitor 5-minute timeout.

Raising the n=2 base to 45s gives docker/image pull and the static-nodes P2P handshake more headroom on contended runners. The +5s/extra-validator slope and 180s cap are unchanged.