### PR TITLE
fix: bake solc cache into deployer runtime to remove network dependency

### DIFF
--- a/docker/pos-contract-deployer.Dockerfile
+++ b/docker/pos-contract-deployer.Dockerfile
@@ -104,6 +104,14 @@ RUN apt-get update \
 COPY --from=builder /usr/local/bin/forge /usr/local/bin/forge
 COPY --from=builder /usr/local/bin/cast /usr/local/bin/cast
 
+# Carry the SVM cache from the builder so forge resolves solc against on-disk
+# binaries (0.5.17 + 0.8.x for pos-contracts, etc.) instead of trying to fetch
+# binaries.soliditylang.org at deploy time. Combined with `offline = true`
+# appended to each foundry.toml below, this guarantees no network egress for
+# compiler resolution — the kurtosis enclave often has no route to the public
+# internet.
+COPY --from=builder /root/.svm /root/.svm
+
 # pos-contracts (anvil-pos) runtime surface: artifacts + contracts + scripts +
 # the one node_modules dir whose paths are actually referenced by contracts/.
 # Keeping src='contracts' so forge doesn't invalidate its build cache;
@@ -111,6 +119,7 @@ COPY --from=builder /usr/local/bin/cast /usr/local/bin/cast
 # node_modules is dropped.
 WORKDIR /opt/pos-contracts-anvil-pos
 COPY --from=builder /opt/pos-contracts-anvil-pos/foundry.toml ./foundry.toml
+RUN sed -i '/^\[profile\.default\]/a offline = true' foundry.toml
 COPY --from=builder /opt/pos-contracts-anvil-pos/lib ./lib
 COPY --from=builder /opt/pos-contracts-anvil-pos/contracts ./contracts
 COPY --from=builder /opt/pos-contracts-anvil-pos/scripts ./scripts
@@ -127,12 +136,14 @@ RUN rm -rf scripts/deployers
 # stripped — we don't run `forge build` here, only `forge create`.
 WORKDIR /opt/pos-contracts-main
 COPY --from=builder /opt/pos-contracts-main/foundry.toml ./foundry.toml
+RUN sed -i '/^\[profile\.default\]/a offline = true' foundry.toml
 COPY --from=builder /opt/pos-contracts-main/out ./out
 
 # pos-portal runtime surface: same idea, but the deploy scripts only use
 # deployCode against pre-built artifacts, so contracts/ isn't needed.
 WORKDIR /opt/pos-portal
 COPY --from=builder /opt/pos-portal/foundry.toml ./foundry.toml
+RUN sed -i '/^\[profile\.default\]/a offline = true' foundry.toml
 COPY --from=builder /opt/pos-portal/lib/forge-std ./lib/forge-std
 COPY --from=builder /opt/pos-portal/scripts/deployment-scripts ./scripts/deployment-scripts
 COPY --from=builder /opt/pos-portal/out ./out
@@ -144,6 +155,7 @@ COPY --from=builder /opt/pos-portal/out ./out
 # for the test files we deliberately excluded.
 WORKDIR /opt/spol-contracts
 COPY --from=builder /opt/spol-contracts/foundry.toml ./foundry.toml
+RUN sed -i '/^\[profile\.default\]/a offline = true' foundry.toml
 COPY --from=builder /opt/spol-contracts/foundry.lock ./foundry.lock
 COPY --from=builder /opt/spol-contracts/soldeer.lock ./soldeer.lock
 COPY --from=builder /opt/spol-contracts/remappings.txt ./remappings.txt

--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -59,7 +59,7 @@ IMAGES = {
     "l2_el_erigon_image": "0xpolygon/erigon:v3.5.0",
     "l2_cl_queue_image": "rabbitmq:4.2.5",
     # utilities
-    "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:0.0.4",
+    "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:0.0.5",
     "pos_el_genesis_builder_image": "ghcr.io/0xpolygon/pos-el-genesis-builder:96a19dd",
     "pos_validator_config_generator_image": "ghcr.io/0xpolygon/pos-validator-config-generator:0.6.0",
     "toolbox_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12",

--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -59,7 +59,7 @@ IMAGES = {
     "l2_el_erigon_image": "0xpolygon/erigon:v3.5.0",
     "l2_cl_queue_image": "rabbitmq:4.2.5",
     # utilities
-    "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:0.0.5",
+    "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:0.0.4",
     "pos_el_genesis_builder_image": "ghcr.io/0xpolygon/pos-el-genesis-builder:96a19dd",
     "pos_validator_config_generator_image": "ghcr.io/0xpolygon/pos-validator-config-generator:0.6.0",
     "toolbox_image": "europe-west2-docker.pkg.dev/prj-polygonlabs-devtools-dev/public/toolbox:0.0.12",


### PR DESCRIPTION
The `pos-contract-deployer:0.0.4` multi-stage refactor copied forge/cast into the runtime image but not the SVM cache. forge script always re-resolves solc per pragma, so each deploy hit binaries.soliditylang.org to install the compiler — and failed when the kurtosis enclave had no egress, breaking deployments like deploy-plasma-bridge.sh.

Carry /root/.svm into runtime so all four solc versions (0.5.17/0.6.6/0.8.30/0.8.34) are on disk, and append `offline = true` to each repo's foundry.toml so a misconfigured cache fails loudly instead of silently re-trying the network.