### PR TITLE
fix(snapshot): make wait_for_checkpoint_quiescence anvil-compatible

### DIFF
--- a/scripts/snapshot/snapshot.sh
+++ b/scripts/snapshot/snapshot.sh
@@ -561,7 +561,12 @@ wait_for_checkpoint_quiescence() {
         return 1
     fi
     cl_api_url=$(kurtosis port print "$enclave_name" "$cl_service" http)
-    l1_rpc_url=$(kurtosis port print "$enclave_name" el-1-geth-lighthouse rpc)
+    # `l1_backend` chooses between a single-node `anvil` service and the
+    # ethereum-package's `el-1-geth-lighthouse`. Both expose `rpc`. Probe
+    # the anvil name first; only one of the two services exists in any
+    # given enclave.
+    l1_rpc_url=$(kurtosis port print "$enclave_name" anvil rpc 2>/dev/null \
+        || kurtosis port print "$enclave_name" el-1-geth-lighthouse rpc)
     root_chain_proxy=$(kurtosis files inspect "$enclave_name" pos-contract-addresses contractAddresses.json \
         | sed -n '/^{/,$p' | jq -r '.root.RootChainProxy')
 


### PR DESCRIPTION
## Why

`wait_for_checkpoint_quiescence` (added in v1.3.1) hardcodes `el-1-geth-lighthouse` as the L1 RPC service. With `l1_backend: anvil`, the L1 service is named `anvil` instead, so `kurtosis port print` exits non-zero and the snapshot pipeline aborts before any quiescence polling happens.

The downstream impact is that anvil-backed consumers (lst-api's e2e snapshot among them) can't take v1.3.1+ snapshots without re-implementing the quiescence loop locally, just to work around the L1 service-name assumption.

## What

Probe `anvil` first via `kurtosis port print … anvil rpc 2>/dev/null`; on failure, fall back to `el-1-geth-lighthouse`. Both backends expose the port under the same name (`rpc`), so this is a one-line discovery change with no behavioural change for ethereum-package enclaves. Six lines including the comment explaining the why.

## Test plan

- [x] Inspected the existing implementation against `src/l1/launcher.star` to confirm `anvil` and `el-1-geth-lighthouse` are the only two L1 service names produced by the supported backends.
- [ ] Reviewer to confirm — if a future L1 backend is added, this needs to grow another probe.
