### PR TITLE
fix(monitor): retry baseline reads on transient errors

### DIFF
--- a/tools/devnet-monitor/internal/probes/bor_blocks.go
+++ b/tools/devnet-monitor/internal/probes/bor_blocks.go
@@ -99,14 +99,23 @@ func monitorBor(ctx context.Context, svc discover.Service, stimulate bool, minBl
 	}
 	defer bor.Close()
 
-	latestBaseline, latestErr := bor.LatestBlock(ctx)
-	finalizedBaseline, finalizedErr := bor.FinalizedBlock(ctx)
-	if latestErr != nil || finalizedErr != nil {
-		lg.Error("Read baseline failed",
-			"node", svc.Name,
-			"latest_err", latestErr,
-			"finalized_err", finalizedErr,
-		)
+	// Retry the baseline pair on transient errors so a node that's still
+	// warming up (e.g. erigon mid-restart after a snapshot restore) gets the
+	// same grace as the poll loop below. The probe shares a single timeout
+	// across baseline + poll loop — if neither read ever succeeds, ctx will
+	// fire and we fail.
+	var latestBaseline, finalizedBaseline uint64
+	if _, err = readWithRetry(ctx, lg, "baseline:"+svc.Name,
+		func(c context.Context) (uint64, error) {
+			var latestErr, finalizedErr error
+			latestBaseline, latestErr = bor.LatestBlock(c)
+			finalizedBaseline, finalizedErr = bor.FinalizedBlock(c)
+			if latestErr != nil {
+				return 0, latestErr
+			}
+			return 0, finalizedErr
+		}); err != nil {
+		lg.Error("Read baseline failed", "node", svc.Name, "err", err)
 		return false
 	}
 	latestRequired := latestBaseline + uint64(minBlocks)

--- a/tools/devnet-monitor/internal/probes/heimdall_api.go
+++ b/tools/devnet-monitor/internal/probes/heimdall_api.go
@@ -54,7 +54,8 @@ func pollHeimdallCounter(
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	baseline, err := readWithRetry(ctx, lg, "baseline", read, h)
+	baseline, err := readWithRetry(ctx, lg, "baseline",
+		func(c context.Context) (uint64, error) { return read(c, h) })
 	if err != nil {
 		lg.Error("Read baseline failed", "err", err)
 		res.Failed = 1
@@ -116,18 +117,22 @@ func pollHeimdallCounter(
 
 // readWithRetry retries the read on transient errors until it succeeds or ctx
 // expires. Uses the same pollInterval cadence as the main loop.
+//
+// The reader is a context-only closure so callers can bind their own client
+// type (heimdall, bor, …) and read shape (single counter, or multi-read
+// returning the first error from a pair). Shared across all probes that need
+// resilient baseline reads.
 func readWithRetry(
 	ctx context.Context,
 	lg *slog.Logger,
 	what string,
-	read func(context.Context, *chain.Heimdall) (uint64, error),
-	h *chain.Heimdall,
+	read func(context.Context) (uint64, error),
 ) (uint64, error) {
 	tick := time.NewTicker(pollInterval)
 	defer tick.Stop()
 	var lastErr error
 	for {
-		v, err := read(ctx, h)
+		v, err := read(ctx)
 		if err == nil {
 			return v, nil
 		}

--- a/tools/devnet-monitor/internal/probes/heimdall_blocks.go
+++ b/tools/devnet-monitor/internal/probes/heimdall_blocks.go
@@ -67,7 +67,13 @@ func (Heimdall) Run(ctx context.Context, dn discover.Devnet, opts probeapi.Optio
 func monitorHeimdall(ctx context.Context, svc discover.Service, minBlocks int, lg *slog.Logger) bool {
 	h := chain.DialHeimdall(svc.URL)
 
-	baseline, err := h.Height(ctx)
+	// Retry the baseline read on transient errors so a node that's still
+	// warming up (e.g. heimdall mid-restart after a snapshot restore) gets
+	// the same grace as the poll loop below. The probe shares a single
+	// timeout across baseline + poll loop — if the read never succeeds,
+	// ctx will fire and we fail.
+	baseline, err := readWithRetry(ctx, lg, "baseline:"+svc.Name,
+		func(c context.Context) (uint64, error) { return h.Height(c) })
 	if err != nil {
 		lg.Error("Read baseline failed", "node", svc.Name, "err", err)
 		return false

--- a/tools/devnet-monitor/internal/probes/heimdall_blocks_test.go
+++ b/tools/devnet-monitor/internal/probes/heimdall_blocks_test.go
@@ -84,6 +84,21 @@ func TestMonitorHeimdall_TransientErrors(t *testing.T) {
 	}
 }
 
+// TestMonitorHeimdall_BaselineRetried: baseline read errors initially but
+// recovers within the timeout — probe should succeed.
+func TestMonitorHeimdall_BaselineRetried(t *testing.T) {
+	script := []cometStep{
+		{ok: false},             // baseline attempt 1: 503
+		{ok: false},             // baseline attempt 2: 503
+		{ok: true, height: 100}, // baseline attempt 3: OK
+		{ok: true, height: 160}, // poll: past 100+50
+	}
+	ok, _ := runHeimdallBlocksProbe(t, script, 50, 2*time.Second)
+	if !ok {
+		t.Fatal("expected success after baseline retry, got failure")
+	}
+}
+
 // TestMonitorHeimdall_StallFails: height never advances → fail.
 func TestMonitorHeimdall_StallFails(t *testing.T) {
 	script := []cometStep{


### PR DESCRIPTION
PR #562 made the poll loop resilient to transient read errors, but the baseline read in front of each loop still failed-fast: one connection- refused on `LatestBlock` / `FinalizedBlock` / `Height` would mark the node failed and skip the entire poll budget.

That bit the daily snapshot job's monitor step against the large devnet — the erigon RPC (`pos-l2-el-10-erigon-heimdall-v2-rpc`) was mid-restart from its `while ! erigon` retry loop when the monitor started, so the baseline read got `dial tcp [::1]:9554: connect: connection refused` and the probe reported `failed=1` after ~50 ms, despite the chain producing 50+ blocks over the next minute.

Reuse `readWithRetry` (introduced in #562 for `pollHeimdallCounter`'s baseline) to wrap the baseline reads in `monitorBor` and `monitorHeimdall` too. To make it usable across client types, change its reader argument from `func(ctx, *chain.Heimdall) (uint64, error)` to a client-bound `func(ctx) (uint64, error)` closure. Adapt the existing heimdall_api.go callsite. The bor probe needs both `LatestBlock` and `FinalizedBlock` per attempt — its closure runs both, captures the values into the outer scope, and returns the first non-nil error so either failure triggers a retry.

Add `TestMonitorHeimdall_BaselineRetried` mirroring the existing `TestPollHeimdallCounter_BaselineRetried`; reverted-source check confirms the test fails on the pre-fix code.