### PR TITLE
chore(ci): bump pinned pos-e2e ref to 967ba87

### DIFF
--- a/.github/actions/test/bridge/action.yml
+++ b/.github/actions/test/bridge/action.yml
@@ -16,7 +16,7 @@ inputs:
   pos_e2e_tag:
     description: The git tag, branch, or commit hash of 0xPolygon/pos-e2e
     required: false
-    default: 3e1b345a7ae36cce9a0076e0b41c713601048b2e
+    default: 967ba8772584b3c2aadcb69b40606d266fecc76f
   pos_e2e_token:
     description: GitHub token with read access to 0xPolygon/pos-e2e
     required: true

--- a/.github/actions/test/e2e/action.yml
+++ b/.github/actions/test/e2e/action.yml
@@ -5,7 +5,7 @@ inputs:
   pos_e2e_tag:
     description: The git tag, branch, or commit hash of 0xPolygon/pos-e2e
     required: false
-    default: 3e1b345a7ae36cce9a0076e0b41c713601048b2e
+    default: 967ba8772584b3c2aadcb69b40606d266fecc76f
   pos_e2e_token:
     description: GitHub token with read access to 0xPolygon/pos-e2e
     required: true


### PR DESCRIPTION
Picks up 0xPolygon/pos-e2e#37, which fixes resolve_service_name's compose path to return the bare candidate name instead of the enclave-prefixed compose key. The previous pin (3e1b345) broke the snapshot job's bridge test in pos_setup with `❌ resolve_url: no port mapping for service=pos-l2-el-1-bor-heimdall-v2-validator-archive port=rpc`, since the prefixed name didn't match resolve_url's bare `l2-el-*` case.

Bumps both action defaults (bridge + e2e) — same pin, applied consistently across the two callers.