### PR TITLE
chore: pin erigon to v3.5.0

### DIFF
--- a/src/config/constants.star
+++ b/src/config/constants.star
@@ -55,7 +55,7 @@ IMAGES = {
     # layer 2
     "l2_cl_heimdall_v2_image": "0xpolygon/heimdall-v2:0.7.1",
     "l2_el_bor_image": "0xpolygon/bor:2.8.0",
-    "l2_el_erigon_image": "0xpolygon/erigon:v3.6.0",
+    "l2_el_erigon_image": "0xpolygon/erigon:v3.5.0",
     "l2_cl_queue_image": "rabbitmq:4.2.5",
     # utilities
     "pos_contract_deployer_image": "ghcr.io/0xpolygon/pos-contract-deployer:0.0.4",


### PR DESCRIPTION
Erigon v3.6.0 fails to peer with bor v2.8.0 after snapshot restore (forkid mismatch), causing the snapshot CI's large job to fail at the monitor step because erigon has no peers and is stuck at the snapshot block. Pin erigon back to v3.5.0 as a workaround — v3.5.0 happens to compute the same (wrong-but-symmetric) forkid as bor and they peer fine.

Upstream fix proposed on bor: <https://github.com/0xPolygon/bor/tree/leo/forkid-fix>
