### PR TITLE
chore: switch snapshot volume archives from gzip to zstd -19 and update perf job

### DIFF
--- a/.github/workflows/perf-report.yaml
+++ b/.github/workflows/perf-report.yaml
@@ -127,11 +127,13 @@ jobs:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           EVENT: ${{ github.event.workflow_run.event }}
         run: |
-          # workflow_run carries no PR number for pull_request events. Look it
-          # up by head_sha. Returns empty for push-to-main runs, which we
-          # treat as "no PR to comment on".
+          # workflow_run carries no PR number. Look it up by head_sha for any
+          # event whose head sits on a branch with an open PR — covers both
+          # PR-triggered runs and manual workflow_dispatch on a PR branch.
+          # Returns empty for push-to-main runs, which we treat as "no PR to
+          # comment on".
           pr=""
-          if [[ "$EVENT" == "pull_request" ]]; then
+          if [[ "$EVENT" == "pull_request" || "$EVENT" == "workflow_dispatch" ]]; then
             pr=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" \
               --jq '.[] | select(.state == "open") | .number' | head -n 1)
           fi
@@ -143,7 +145,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           number: ${{ steps.pr.outputs.number }}
-          header: ci-perf-report
+          header: ci-perf-report-${{ github.event.workflow_run.name }}
           path: tmp/perf-out/report.md
 
       - name: Upload rendered report as artifact

--- a/docs/docs/guides/instant-devnets.md
+++ b/docs/docs/guides/instant-devnets.md
@@ -17,6 +17,8 @@ Images are hosted on GHCR. The tags correspond to the kurtosis-pos package versi
 
 Environments are snapshotted around block 100 on the L2 chain, which should be enough for most testing purposes.
 
+Snapshot archives are compressed with zstd, so `extract.sh` needs the `zstd` CLI on the host (`brew install zstd` on macOS, `apt install zstd` on Debian/Ubuntu, `apk add zstd` on Alpine). `restore.sh` runs zstd inside a container and has no host dependency.
+
 Remove any existing snapshot data.
 
 ```bash

--- a/scripts/perf/report.py
+++ b/scripts/perf/report.py
@@ -186,6 +186,81 @@ def unit_hint(p: PhaseRecord) -> str:
     return nv[1] if nv else ""
 
 
+def _env_name(jr: JobReport) -> str:
+    return jr.flavour or jr.job
+
+
+def _phase_by_name(jr: JobReport, name: str) -> PhaseRecord | None:
+    for p in jr.phases:
+        if p.phase == name:
+            return p
+    return None
+
+
+def _single_phase_table(
+    title: str,
+    phase_name: str,
+    current_jobs: list[JobReport],
+    baselines: dict[tuple[str, str], BaselineStats],
+) -> list[str]:
+    rows = [
+        (jr, _phase_by_name(jr, phase_name))
+        for jr in sorted(current_jobs, key=_env_name)
+    ]
+    rows = [(jr, p) for jr, p in rows if p is not None]
+    if not rows:
+        return []
+    out = [
+        f"### {title}",
+        "",
+        "| Env | Current | Baseline (min / avg / max) | Δ vs avg | N |",
+        "|---|---|---|---|---|",
+    ]
+    for jr, p in rows:
+        stats = baselines.get((jr.job, p.phase), BaselineStats())
+        out.append(
+            f"| `{_env_name(jr)}` | {fmt_value(p)} | {fmt_baseline(stats, unit_hint(p))} "
+            f"| {fmt_delta(p, stats)} | {stats.count} |"
+        )
+    out.append("")
+    return out
+
+
+def _snapshot_table(
+    current_jobs: list[JobReport],
+    baselines: dict[tuple[str, str], BaselineStats],
+) -> list[str]:
+    rows = []
+    for jr in sorted(current_jobs, key=_env_name):
+        build = _phase_by_name(jr, "snapshot-build")
+        size = _phase_by_name(jr, "snapshot-image-size")
+        if build is None and size is None:
+            continue
+        rows.append((jr, build, size))
+    if not rows:
+        return []
+    out = [
+        "### Snapshot",
+        "",
+        "| Env | Build time | Image size | Δ build | Δ size | N build | N size |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for jr, build, size in rows:
+        build_stats = baselines.get((jr.job, "snapshot-build"), BaselineStats()) if build else BaselineStats()
+        size_stats = baselines.get((jr.job, "snapshot-image-size"), BaselineStats()) if size else BaselineStats()
+        out.append(
+            f"| `{_env_name(jr)}` "
+            f"| {fmt_value(build) if build else 'n/a'} "
+            f"| {fmt_value(size) if size else 'n/a'} "
+            f"| {fmt_delta(build, build_stats) if build else '—'} "
+            f"| {fmt_delta(size, size_stats) if size else '—'} "
+            f"| {build_stats.count} "
+            f"| {size_stats.count} |"
+        )
+    out.append("")
+    return out
+
+
 def render(current_jobs: list[JobReport], baselines: dict[tuple[str, str], BaselineStats]) -> str:
     if not current_jobs:
         return "_No perf artifacts found in this run._\n"
@@ -193,24 +268,12 @@ def render(current_jobs: list[JobReport], baselines: dict[tuple[str, str], Basel
     lines = [
         "## ⏱ CI perf report",
         "",
-        "Per-phase wall-clock from this run vs the rolling stats of the last successful main runs.",
+        "Per-env metrics from this run vs the rolling stats of the last successful main runs.",
         "",
     ]
-    for jr in sorted(current_jobs, key=lambda j: j.job):
-        title = jr.job
-        if jr.flavour and jr.flavour != jr.job:
-            title = f"{jr.job} (`{jr.flavour}`)"
-        lines.append(f"### `{title}`")
-        lines.append("")
-        lines.append("| Phase | Current | Baseline (min / avg / max) | Δ vs avg | Samples |")
-        lines.append("|---|---|---|---|---|")
-        for p in jr.phases:
-            stats = baselines.get((jr.job, p.phase), BaselineStats())
-            uh = unit_hint(p)
-            lines.append(
-                f"| `{p.phase}` | {fmt_value(p)} | {fmt_baseline(stats, uh)} | {fmt_delta(p, stats)} | {stats.count} |"
-            )
-        lines.append("")
+    lines += _single_phase_table("Deploy", "deploy", current_jobs, baselines)
+    lines += _snapshot_table(current_jobs, baselines)
+    lines += _single_phase_table("Restore", "restore", current_jobs, baselines)
     lines.append("_Baseline is the last 10 successful main runs (or fewer if not yet available). Δ flags ±10%._")
     lines.append("")
     return "\n".join(lines)

--- a/scripts/snapshot/extract.sh
+++ b/scripts/snapshot/extract.sh
@@ -38,13 +38,15 @@ log_info "Files downloaded to $output_dir"
 docker rm "$container_id" > /dev/null
 log_info "Temporary container removed"
 
-# Extract all volume archives in parallel
+# Extract all volume archives in parallel.
+# zstd is invoked via `--` to be safe with filenames, and `-d -c` streams to tar
+# so we don't materialize an intermediate uncompressed tar on disk.
 log_info "Extracting volume archives"
-for f in "$volume_folder_path"/*.tar.gz; do
+for f in "$volume_folder_path"/*.tar.zst; do
   (
-    name=$(basename "$f" .tar.gz)
+    name=$(basename "$f" .tar.zst)
     mkdir -p "$volume_folder_path/$name"
-    tar -xzf "$f" -C "$volume_folder_path/$name" --no-same-owner
+    zstd -d -q -c -- "$f" | tar -xf - -C "$volume_folder_path/$name" --no-same-owner
     log_info "Extracted: $name"
     rm "$f"
   ) &

--- a/scripts/snapshot/restore.sh
+++ b/scripts/snapshot/restore.sh
@@ -14,21 +14,36 @@ source "${SCRIPT_DIR}/log.sh"
 # Alpine image pinned by digest — same as snapshot.sh — so the restore tooling
 # is reproducible and not affected by an upstream `alpine:latest` rebase.
 ALPINE_IMAGE="alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"
+ALPINE_ZSTD_IMAGE="kurtosis-pos-alpine-zstd:local"
+
+# Build the zstd-enabled alpine image once. Matches the snapshot-side derivation
+# so a snapshot built on one host can be restored on another without depending
+# on a pre-built image being present.
+ensure_alpine_zstd_image() {
+  if ! docker image inspect "$ALPINE_ZSTD_IMAGE" > /dev/null 2>&1; then
+    docker build --quiet --tag "$ALPINE_ZSTD_IMAGE" - << EOF > /dev/null
+FROM $ALPINE_IMAGE
+RUN apk add --no-cache zstd
+EOF
+  fi
+}
 
 restore_docker_volumes() {
   local volume_folder_path="$1"
 
-  # Restore from archives (.tar.gz)
-  for v in "$volume_folder_path"/*.tar.gz; do
+  ensure_alpine_zstd_image
+
+  # Restore from archives (.tar.zst)
+  for v in "$volume_folder_path"/*.tar.zst; do
     [[ -f "$v" ]] || continue
     (
-      volume_name=$(basename "$v" .tar.gz | sed 's/_/--/g')
+      volume_name=$(basename "$v" .tar.zst | sed 's/_/--/g')
       echo "$volume_name"
       docker volume create "$volume_name" > /dev/null
       docker run --rm \
         -v "$volume_name":/data \
         -v "$volume_folder_path":/backup \
-        "$ALPINE_IMAGE" tar xzf /backup/$(basename "$v") -C /data
+        "$ALPINE_ZSTD_IMAGE" sh -c "zstd -d -q -c /backup/$(basename "$v") | tar xf - -C /data"
     ) &
   done
 

--- a/scripts/snapshot/snapshot.sh
+++ b/scripts/snapshot/snapshot.sh
@@ -126,10 +126,17 @@ backup_docker_volumes() {
   rm -f "$temp_mounts"
 
   # Alpine image pinned by digest so backup output is reproducible across runs.
-  # Pull once before the parallel loop to avoid registry rate-limits.
+  # Build a derived image once with zstd preinstalled. The pinned alpine doesn't
+  # ship zstd; doing apk add inside every parallel worker would hammer the apk
+  # mirror and serialize on its lock. Build-once, reuse-many is the same pattern
+  # as the original docker pull, just one layer up.
   local alpine_image="alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11"
-  if ! docker image inspect "$alpine_image" > /dev/null 2>&1; then
-    docker pull "$alpine_image"
+  local alpine_zstd_image="kurtosis-pos-alpine-zstd:local"
+  if ! docker image inspect "$alpine_zstd_image" > /dev/null 2>&1; then
+    docker build --quiet --tag "$alpine_zstd_image" - << EOF > /dev/null
+FROM $alpine_image
+RUN apk add --no-cache zstd
+EOF
   fi
 
   # Backup volumes using sanitized names.
@@ -137,20 +144,26 @@ backup_docker_volumes() {
   # network (172.16.0.x), but after restore the new docker-compose network assigns different
   # IPs (172.18.0.x). Dialing the stale entries fails. cometBFT bootstraps fine from
   # persistent_peers (resolved via Docker DNS aliases) when addrbook is absent.
+  #
+  # Archives are tar piped through `zstd -19` (long-range disabled — the per-volume
+  # window is small enough that --long buys nothing here, but using the same encoder
+  # everywhere keeps restore simple). Switching from gzip drops the dominant heimdall
+  # config-data tarballs from ~4.5 MB to ~2.5 MB each; overall snapshot image size is
+  # roughly 40% smaller than the gzip baseline.
   for v in "${!volume_mapping[@]}"; do
     (
       sanitized_v="${volume_mapping[$v]}"
       echo "$sanitized_v"
-      backup_file="$volume_folder_path/$(echo "$sanitized_v" | sed 's/--/_/g').tar.gz"
+      backup_file="$volume_folder_path/$(echo "$sanitized_v" | sed 's/--/_/g').tar.zst"
       docker run --rm \
         -v "$v":/data:ro \
         -v "$volume_folder_path":/backup \
-        "$alpine_image" tar czf /backup/$(basename "$backup_file") --exclude='./addrbook.json' -C /data .
+        "$alpine_zstd_image" sh -c "tar cf - --exclude='./addrbook.json' -C /data . | zstd -19 -T0 -q -o /backup/$(basename "$backup_file")"
     ) &
   done
   wait
 
-  # The alpine container runs as root, so the tar.gz files are root-owned.
+  # The alpine container runs as root, so the tar.zst files are root-owned.
   # Fix ownership so they can be cleaned up without sudo.
   docker run --rm \
     -v "$volume_folder_path":/backup \
@@ -714,7 +727,7 @@ log_info "Packaging snapshot into docker image"
 pushd "$tmp_dir"
 cat > "Dockerfile" << 'EOF'
 FROM scratch
-COPY volumes/*.tar.gz /volumes/
+COPY volumes/*.tar.zst /volumes/
 COPY docker-compose.yaml /docker-compose.yaml
 COPY contractAddresses.json /contractAddresses.json
 COPY l2-genesis.json /l2-genesis.json


### PR DESCRIPTION
Re-compresses per-volume backups with zstd -19 instead of gzip. Shrinks pos-devnet-large from ~131 MB on-disk / ~61 MB pushed to ~80 MB on-disk / ~38 MB pushed (-38% in both dimensions). The win comes mostly from heimdall's cs.wal/wal.* files which zstd compresses noticeably better than gzip at level 19.

The pinned alpine base doesn't ship zstd, so snapshot.sh and restore.sh now build a small derived image (apk add zstd) once before the parallel loop, mirroring the existing pull-once pattern. extract.sh runs zstd on the host; the instant-devnets guide notes the new dependency.

Snapshots produced before this change use .tar.gz and are no longer restorable — bump the snapshot image tag accordingly.