### PR TITLE
fix(ci): pass -X GET to gh api in perf-report baseline lookup

### DIFF
--- a/.github/workflows/perf-report.yaml
+++ b/.github/workflows/perf-report.yaml
@@ -77,7 +77,9 @@ jobs:
           mkdir -p tmp/perf-baseline
           # /actions/runs returns runs across all workflows; widen the page to
           # 100 so the post-filter by workflow name still leaves enough samples.
-          runs_listing=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs" \
+          # -X GET is required: gh api defaults to POST when any -f field is
+          # supplied, which 404s on this GET-only endpoint.
+          runs_listing=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/runs" \
             -f "branch=main" \
             -f "status=success" \
             -f "per_page=100" \


### PR DESCRIPTION
gh api defaults to POST when any -f field is supplied, so the baseline listing call was POSTing to /actions/runs and getting 404. The 404 JSON body was then parsed as a list of run IDs and a `{` token leaked into the next URL, producing `invalid control character in URL` downstream.

Adding -X GET forces the right method. Verified locally against 0xPolygon/kurtosis-pos: same args, same --jq, now returns IDs.

Failing run: https://github.com/0xPolygon/kurtosis-pos/actions/runs/26444119823