### PR TITLE
feat: enable bor gRPC transport by default

### DIFF
--- a/src/cl/heimdall_v2/launcher.star
+++ b/src/cl/heimdall_v2/launcher.star
@@ -43,7 +43,6 @@ def launch(
                     "el_rpc_url": el_rpc_url,
                     "el_grpc_url": el_grpc_url,
                     "l1_rpc_url": l1_rpc_url,
-                    "cl_bor_grpc_flag": participant.get("cl_bor_grpc_flag"),
                     # Port numbers.
                     "rest_api_port_number": shared.REST_API_PORT_NUMBER,
                     "grpc_port_number": shared.GRPC_PORT_NUMBER,

--- a/src/config/input_parser.star
+++ b/src/config/input_parser.star
@@ -84,7 +84,6 @@ POLYGON_POS_PARTICIPANT = {
     "cl_indexer_pruning_enabled": constants.CL_INDEXER_PRUNING_ENABLED,
     "el_type": constants.EL_TYPE.bor,
     "el_image": constants.IMAGES.get("l2_el_bor_image"),
-    "cl_bor_grpc_flag": False,
     "count": 1,
 }
 

--- a/src/config/sanity_check.star
+++ b/src/config/sanity_check.star
@@ -26,7 +26,6 @@ POLYGON_POS_PARAMS = {
         "el_bor_sync_with_witness",  # Enable bor to sync new blocks using witnesses.
         "el_bor_stateless_parallel_import",  # Enable bor to use parallel import in stateless mode.
         "el_bor_archive_mode",  # Run bor with gcmode=archive for full historical state retention.
-        "cl_bor_grpc_flag",  # Enable heimdall → bor gRPC transport (default HTTP).
         "count",
     ],
     "setup_images": [

--- a/static_files/cl/heimdall_v2/app.toml
+++ b/static_files/cl/heimdall_v2/app.toml
@@ -247,7 +247,9 @@ eth_rpc_url = "{{.l1_rpc_url}}"
 bor_rpc_url = "{{.el_rpc_url}}"
 
 # GRPC flag for bor chain
-bor_grpc_flag = "{{.cl_bor_grpc_flag}}"
+# Enabled by default — gRPC transport for heimdall → bor comms (lower extendVote latency
+# vs HTTP). To revert to HTTP, set this to "false".
+bor_grpc_flag = "true"
 
 # GRPC endpoint for bor chain
 bor_grpc_url = "{{.el_grpc_url}}"


### PR DESCRIPTION
Remove the `cl_bor_grpc_flag` participant knob and hardcode gRPC on in the heimdall configuration. gRPC significantly improves heimdall ↔ bor communications. To revert to HTTP, set `bor_grpc_flag = "false"` in the app.toml template directly.