### PR TITLE
fix: sPOL bridge mappings + anvil L1 backend support in the snapshot pipeline

### DIFF
--- a/scripts/snapshot/extract.sh
+++ b/scripts/snapshot/extract.sh
@@ -33,6 +33,8 @@ docker cp "$container_id:/volumes/." "$volume_folder_path/"
 docker cp "$container_id:/docker-compose.yaml" "$output_dir/docker-compose.yaml"
 docker cp "$container_id:/contractAddresses.json" "$output_dir/contractAddresses.json"
 docker cp "$container_id:/l2-genesis.json" "$output_dir/l2-genesis.json"
+# Only present for anvil-backend snapshots (see snapshot.sh); tolerate absence.
+docker cp "$container_id:/anvil-state.hex" "$output_dir/anvil-state.hex" 2> /dev/null || true
 log_info "Files downloaded to $output_dir"
 
 docker rm "$container_id" > /dev/null

--- a/scripts/snapshot/restore.sh
+++ b/scripts/snapshot/restore.sh
@@ -87,15 +87,17 @@ docker_compose_file="$snapshot_folder/docker-compose.yaml"
 docker compose --file "$docker_compose_file" up --detach --wait
 log_info "Devnet started"
 
-# Re-apply the anvil L1 backend's captured state. snapshot.sh wrote the live
-# post-deploy state to /opt/anvil/state_dump.hex (a captured volume) via the
-# `anvil_dumpState` RPC, because anvil's `--dump-state` writes only on SIGINT —
-# not the SIGTERM the stop sequence sends — so the on-disk state isn't otherwise
-# captured. Replay it via `anvil_loadState` so the restored devnet has the
-# deployed L1 contracts. No-op under the ethereum-package L1 backend (no anvil
-# service). snapshot.sh::configure_ports binds anvil to host 8545.
-anvil_service=$(docker compose --file "$docker_compose_file" config --services 2> /dev/null | grep -E -- '(^|-)anvil$' | head -1 || true)
-if [[ -n "$anvil_service" ]]; then
+# Re-apply the anvil L1 backend's captured state. snapshot.sh baked the live
+# post-deploy anvil state (captured via the `anvil_dumpState` RPC) into the
+# image as /anvil-state.hex, which extract.sh wrote out to the snapshot folder.
+# anvil's own `--dump-state` writes only on SIGINT (not the SIGTERM the stop
+# sequence sends), so the on-disk state isn't otherwise captured. Replay the hex
+# via `anvil_loadState` so the restored devnet has the deployed L1 contracts.
+# The file is present only for anvil-backend snapshots; absent under the
+# ethereum-package backend, where this is a no-op. snapshot.sh::configure_ports
+# binds anvil to host 8545.
+anvil_state_file="$snapshot_folder/anvil-state.hex"
+if [[ -s "$anvil_state_file" ]]; then
   anvil_rpc_url="http://127.0.0.1:8545"
   log_info "Re-applying captured anvil state via ${anvil_rpc_url} (anvil_loadState)"
   # `up --wait` gates on anvil's container healthcheck, which doesn't exercise
@@ -110,32 +112,22 @@ if [[ -n "$anvil_service" ]]; then
     fi
     sleep 1
   done
-  # Stream the hex out, then assemble the JSON-RPC body in a file: the blob is
-  # multi-MB and exceeds ARG_MAX as a command-line argument, so it must go
-  # through file/pipe redirection end to end.
-  anvil_state_hex_file=$(mktemp)
-  docker compose --file "$docker_compose_file" exec -T "$anvil_service" \
-    cat /opt/anvil/state_dump.hex > "$anvil_state_hex_file" 2> /dev/null || true
-  if [[ "$(wc -c < "$anvil_state_hex_file")" -lt 100 ]]; then
-    log_warn "anvil ${anvil_service}:/opt/anvil/state_dump.hex missing or empty — snapshot predates the anvil-state capture; skipping"
-    rm -f "$anvil_state_hex_file"
-  else
-    anvil_body_file=$(mktemp)
-    {
-      printf '{"jsonrpc":"2.0","method":"anvil_loadState","params":["'
-      cat "$anvil_state_hex_file"
-      printf '"],"id":1}'
-    } > "$anvil_body_file"
-    rm -f "$anvil_state_hex_file"
-    anvil_load_response=$(curl -fsSL -X POST -H 'Content-Type: application/json' \
-      --data-binary "@${anvil_body_file}" "$anvil_rpc_url")
-    rm -f "$anvil_body_file"
-    if ! printf '%s' "$anvil_load_response" | jq -e '.result == true' > /dev/null 2>&1; then
-      log_error "anvil_loadState rejected the captured state: ${anvil_load_response}"
-      exit 1
-    fi
-    log_info "anvil L1 state restored"
+  # Assemble the JSON-RPC body in a file: the hex blob is multi-MB and exceeds
+  # ARG_MAX as a command-line argument, so it goes through file redirection.
+  anvil_body_file=$(mktemp)
+  {
+    printf '{"jsonrpc":"2.0","method":"anvil_loadState","params":["'
+    cat "$anvil_state_file"
+    printf '"],"id":1}'
+  } > "$anvil_body_file"
+  anvil_load_response=$(curl -fsSL -X POST -H 'Content-Type: application/json' \
+    --data-binary "@${anvil_body_file}" "$anvil_rpc_url")
+  rm -f "$anvil_body_file"
+  if ! printf '%s' "$anvil_load_response" | jq -e '.result == true' > /dev/null 2>&1; then
+    log_error "anvil_loadState rejected the captured state: ${anvil_load_response}"
+    exit 1
   fi
+  log_info "anvil L1 state restored"
 fi
 
 log_info "Use 'docker compose --file $docker_compose_file down --volumes' to remove the devnet"

--- a/scripts/snapshot/restore.sh
+++ b/scripts/snapshot/restore.sh
@@ -87,4 +87,55 @@ docker_compose_file="$snapshot_folder/docker-compose.yaml"
 docker compose --file "$docker_compose_file" up --detach --wait
 log_info "Devnet started"
 
+# Re-apply the anvil L1 backend's captured state. snapshot.sh wrote the live
+# post-deploy state to /opt/anvil/state_dump.hex (a captured volume) via the
+# `anvil_dumpState` RPC, because anvil's `--dump-state` writes only on SIGINT —
+# not the SIGTERM the stop sequence sends — so the on-disk state isn't otherwise
+# captured. Replay it via `anvil_loadState` so the restored devnet has the
+# deployed L1 contracts. No-op under the ethereum-package L1 backend (no anvil
+# service). snapshot.sh::configure_ports binds anvil to host 8545.
+anvil_service=$(docker compose --file "$docker_compose_file" config --services 2> /dev/null | grep -E -- '(^|-)anvil$' | head -1 || true)
+if [[ -n "$anvil_service" ]]; then
+  anvil_rpc_url="http://127.0.0.1:8545"
+  log_info "Re-applying captured anvil state via ${anvil_rpc_url} (anvil_loadState)"
+  # `up --wait` gates on anvil's container healthcheck, which doesn't exercise
+  # the JSON-RPC; poll until the RPC actually answers before loading state.
+  deadline=$((SECONDS + 60))
+  until curl -fsSL -X POST -H 'Content-Type: application/json' \
+    --data '{"jsonrpc":"2.0","method":"web3_clientVersion","id":1}' \
+    "$anvil_rpc_url" > /dev/null 2>&1; do
+    if [[ "$SECONDS" -gt "$deadline" ]]; then
+      log_error "anvil RPC at ${anvil_rpc_url} did not respond within 60s"
+      exit 1
+    fi
+    sleep 1
+  done
+  # Stream the hex out, then assemble the JSON-RPC body in a file: the blob is
+  # multi-MB and exceeds ARG_MAX as a command-line argument, so it must go
+  # through file/pipe redirection end to end.
+  anvil_state_hex_file=$(mktemp)
+  docker compose --file "$docker_compose_file" exec -T "$anvil_service" \
+    cat /opt/anvil/state_dump.hex > "$anvil_state_hex_file" 2> /dev/null || true
+  if [[ "$(wc -c < "$anvil_state_hex_file")" -lt 100 ]]; then
+    log_warn "anvil ${anvil_service}:/opt/anvil/state_dump.hex missing or empty — snapshot predates the anvil-state capture; skipping"
+    rm -f "$anvil_state_hex_file"
+  else
+    anvil_body_file=$(mktemp)
+    {
+      printf '{"jsonrpc":"2.0","method":"anvil_loadState","params":["'
+      cat "$anvil_state_hex_file"
+      printf '"],"id":1}'
+    } > "$anvil_body_file"
+    rm -f "$anvil_state_hex_file"
+    anvil_load_response=$(curl -fsSL -X POST -H 'Content-Type: application/json' \
+      --data-binary "@${anvil_body_file}" "$anvil_rpc_url")
+    rm -f "$anvil_body_file"
+    if ! printf '%s' "$anvil_load_response" | jq -e '.result == true' > /dev/null 2>&1; then
+      log_error "anvil_loadState rejected the captured state: ${anvil_load_response}"
+      exit 1
+    fi
+    log_info "anvil L1 state restored"
+  fi
+fi
+
 log_info "Use 'docker compose --file $docker_compose_file down --volumes' to remove the devnet"

--- a/scripts/snapshot/restore.sh
+++ b/scripts/snapshot/restore.sh
@@ -117,7 +117,9 @@ if [[ -s "$anvil_state_file" ]]; then
   anvil_body_file=$(mktemp)
   {
     printf '{"jsonrpc":"2.0","method":"anvil_loadState","params":["'
-    cat "$anvil_state_file"
+    # Strip any whitespace (a stray trailing newline embedded mid-string would
+    # make the JSON-RPC body invalid); the hex itself has no internal spaces.
+    tr -d '[:space:]' < "$anvil_state_file"
     printf '"],"id":1}'
   } > "$anvil_body_file"
   anvil_load_response=$(curl -fsSL -X POST -H 'Content-Type: application/json' \

--- a/scripts/snapshot/snapshot.sh
+++ b/scripts/snapshot/snapshot.sh
@@ -658,6 +658,41 @@ wait_for_checkpoint_quiescence() {
 log_info "Waiting for heimdall's checkpoint ack_count to catch up with L1"
 wait_for_checkpoint_quiescence "$enclave_name"
 
+# Persist the anvil L1 backend's post-deploy state into the snapshot.
+# anvil boots `--load-state /opt/anvil/genesis.json --dump-state /tmp/state_dump.json`
+# (src/l1/anvil.star): the dump path is /tmp (not a captured volume) AND anvil
+# only writes it on SIGINT, not the SIGTERM that the stop sequence below sends —
+# so without intervention the deployed L1 contracts and checkpoint state are
+# lost on restore and the restored devnet comes up on bare genesis. Capture the
+# live state via the `anvil_dumpState` RPC and write the hex blob into the anvil
+# container's /opt/anvil volume, which IS captured; restore.sh replays it via
+# `anvil_loadState`. Done after quiescence so the captured anvil state is
+# self-consistent with heimdall's acknowledged checkpoints. No-op under the
+# ethereum-package L1 backend, which has no anvil service.
+anvil_rpc_url=$(kurtosis port print "$enclave_name" anvil rpc 2> /dev/null || true)
+if [[ -n "$anvil_rpc_url" ]]; then
+  log_info "Capturing anvil L1 state via ${anvil_rpc_url} (anvil_dumpState)"
+  anvil_state_hex=$(curl -fsSL -X POST -H 'Content-Type: application/json' \
+    --data '{"jsonrpc":"2.0","method":"anvil_dumpState","params":[],"id":1}' \
+    "$anvil_rpc_url" | jq -r '.result // empty')
+  if [[ "${#anvil_state_hex}" -lt 100 ]]; then
+    log_error "anvil_dumpState returned an unexpectedly short result (${#anvil_state_hex} chars)"
+    exit 1
+  fi
+  anvil_container=$(docker ps --filter "network=kt-$enclave_name" --format '{{.Names}}' | grep '^anvil--' | head -1)
+  if [[ -z "$anvil_container" ]]; then
+    log_error "Could not locate the live anvil container in network kt-$enclave_name"
+    exit 1
+  fi
+  # docker cp from a tempfile rather than piping the (multi-MB) hex through
+  # `docker exec -i ... sh -c 'cat >'`, which can break-pipe on large blobs.
+  anvil_state_local=$(mktemp)
+  printf '%s' "$anvil_state_hex" > "$anvil_state_local"
+  docker cp "$anvil_state_local" "$anvil_container:/opt/anvil/state_dump.hex"
+  rm -f "$anvil_state_local"
+  log_info "Wrote ${#anvil_state_hex} chars of anvil state to ${anvil_container}:/opt/anvil/state_dump.hex"
+fi
+
 # Extract kurtosis file artifacts that post-restore e2e tests need.
 # `kurtosis files inspect` only works on a live enclave, so we have to grab
 # them now and ship them inside the snapshot image alongside the volumes and

--- a/scripts/snapshot/snapshot.sh
+++ b/scripts/snapshot/snapshot.sh
@@ -675,9 +675,12 @@ anvil_rpc_url=$(kurtosis port print "$enclave_name" anvil rpc 2> /dev/null || tr
 if [[ -n "$anvil_rpc_url" ]]; then
   log_info "Capturing anvil L1 state via ${anvil_rpc_url} (anvil_dumpState)"
   anvil_state_tmp=$(mktemp)
+  # `jq -j` (not -r): emit the hex with NO trailing newline. restore.sh splices
+  # the file contents straight into a JSON string, so a trailing newline would
+  # produce an invalid anvil_loadState request body.
   curl -fsSL -X POST -H 'Content-Type: application/json' \
     --data '{"jsonrpc":"2.0","method":"anvil_dumpState","params":[],"id":1}' \
-    "$anvil_rpc_url" | jq -r '.result // empty' > "$anvil_state_tmp"
+    "$anvil_rpc_url" | jq -j '.result // empty' > "$anvil_state_tmp"
   if [[ "$(wc -c < "$anvil_state_tmp")" -lt 100 ]]; then
     log_error "anvil_dumpState returned an unexpectedly short result ($(wc -c < "$anvil_state_tmp") bytes)"
     exit 1

--- a/scripts/snapshot/snapshot.sh
+++ b/scripts/snapshot/snapshot.sh
@@ -658,39 +658,31 @@ wait_for_checkpoint_quiescence() {
 log_info "Waiting for heimdall's checkpoint ack_count to catch up with L1"
 wait_for_checkpoint_quiescence "$enclave_name"
 
-# Persist the anvil L1 backend's post-deploy state into the snapshot.
-# anvil boots `--load-state /opt/anvil/genesis.json --dump-state /tmp/state_dump.json`
-# (src/l1/anvil.star): the dump path is /tmp (not a captured volume) AND anvil
-# only writes it on SIGINT, not the SIGTERM that the stop sequence below sends —
-# so without intervention the deployed L1 contracts and checkpoint state are
-# lost on restore and the restored devnet comes up on bare genesis. Capture the
-# live state via the `anvil_dumpState` RPC and write the hex blob into the anvil
-# container's /opt/anvil volume, which IS captured; restore.sh replays it via
-# `anvil_loadState`. Done after quiescence so the captured anvil state is
-# self-consistent with heimdall's acknowledged checkpoints. No-op under the
-# ethereum-package L1 backend, which has no anvil service.
+# Persist the anvil L1 backend's post-deploy state into the snapshot. anvil
+# boots `--load-state /opt/anvil/genesis.json --dump-state /tmp/state_dump.json`
+# (src/l1/anvil.star): /tmp is not captured, AND anvil writes that dump only on
+# SIGINT (not the SIGTERM the stop sequence below sends) — so without
+# intervention the deployed L1 contracts and checkpoint state are lost on
+# restore and the restored devnet comes up on bare genesis. Capture the live
+# state via the `anvil_dumpState` RPC and bake it into the snapshot IMAGE as
+# /anvil-state.hex (the same image-file bake contractAddresses.json uses — a
+# `docker cp` into the live /opt/anvil files-artifact volume does NOT survive
+# volume capture). restore.sh replays it via `anvil_loadState`. Captured after
+# quiescence so it's consistent with heimdall's acked checkpoints. No-op under
+# the ethereum-package L1 backend, which has no anvil service.
+anvil_state_tmp=""
 anvil_rpc_url=$(kurtosis port print "$enclave_name" anvil rpc 2> /dev/null || true)
 if [[ -n "$anvil_rpc_url" ]]; then
   log_info "Capturing anvil L1 state via ${anvil_rpc_url} (anvil_dumpState)"
-  anvil_state_hex=$(curl -fsSL -X POST -H 'Content-Type: application/json' \
+  anvil_state_tmp=$(mktemp)
+  curl -fsSL -X POST -H 'Content-Type: application/json' \
     --data '{"jsonrpc":"2.0","method":"anvil_dumpState","params":[],"id":1}' \
-    "$anvil_rpc_url" | jq -r '.result // empty')
-  if [[ "${#anvil_state_hex}" -lt 100 ]]; then
-    log_error "anvil_dumpState returned an unexpectedly short result (${#anvil_state_hex} chars)"
+    "$anvil_rpc_url" | jq -r '.result // empty' > "$anvil_state_tmp"
+  if [[ "$(wc -c < "$anvil_state_tmp")" -lt 100 ]]; then
+    log_error "anvil_dumpState returned an unexpectedly short result ($(wc -c < "$anvil_state_tmp") bytes)"
     exit 1
   fi
-  anvil_container=$(docker ps --filter "network=kt-$enclave_name" --format '{{.Names}}' | grep '^anvil--' | head -1)
-  if [[ -z "$anvil_container" ]]; then
-    log_error "Could not locate the live anvil container in network kt-$enclave_name"
-    exit 1
-  fi
-  # docker cp from a tempfile rather than piping the (multi-MB) hex through
-  # `docker exec -i ... sh -c 'cat >'`, which can break-pipe on large blobs.
-  anvil_state_local=$(mktemp)
-  printf '%s' "$anvil_state_hex" > "$anvil_state_local"
-  docker cp "$anvil_state_local" "$anvil_container:/opt/anvil/state_dump.hex"
-  rm -f "$anvil_state_local"
-  log_info "Wrote ${#anvil_state_hex} chars of anvil state to ${anvil_container}:/opt/anvil/state_dump.hex"
+  log_info "Captured $(wc -c < "$anvil_state_tmp") bytes of anvil state for /anvil-state.hex"
 fi
 
 # Extract kurtosis file artifacts that post-restore e2e tests need.
@@ -703,7 +695,7 @@ fi
 #     (L2_STATE_RECEIVER_ADDRESS, used by state-sync helpers).
 contract_addresses_tmp=$(mktemp)
 l2_genesis_tmp=$(mktemp)
-trap "rm -f '$contract_addresses_tmp' '$l2_genesis_tmp'" EXIT
+trap "rm -f '$contract_addresses_tmp' '$l2_genesis_tmp' '$anvil_state_tmp'" EXIT
 log_info "Extracting kurtosis file artifacts"
 # kurtosis files inspect prepends a "File contents:" banner. Strip everything
 # before the first '{' and re-format with jq so the output is canonical JSON.
@@ -765,6 +757,10 @@ log_info "Backups completed"
 # Move the previously-extracted file artifacts into the snapshot tree.
 mv "$contract_addresses_tmp" "$tmp_dir/contractAddresses.json"
 mv "$l2_genesis_tmp" "$tmp_dir/l2-genesis.json"
+# Stage the captured anvil state (anvil backend only) for baking into the image.
+if [[ -n "$anvil_state_tmp" ]]; then
+  mv "$anvil_state_tmp" "$tmp_dir/anvil-state.hex"
+fi
 
 log_info "Generating docker-compose"
 docker_compose_file_path="$tmp_dir/docker-compose.yaml"
@@ -783,6 +779,11 @@ COPY docker-compose.yaml /docker-compose.yaml
 COPY contractAddresses.json /contractAddresses.json
 COPY l2-genesis.json /l2-genesis.json
 EOF
+# Bake the captured anvil L1 state (anvil backend only) so restore.sh can
+# replay it; absent under the ethereum-package backend.
+if [[ -f "anvil-state.hex" ]]; then
+  echo "COPY anvil-state.hex /anvil-state.hex" >> "Dockerfile"
+fi
 # Build the docker image
 image_name="pos-devnet"
 docker build --tag "$image_name" .

--- a/scripts/snapshot/snapshot.sh
+++ b/scripts/snapshot/snapshot.sh
@@ -461,6 +461,22 @@ configure_ports() {
         )
     ' "$docker_compose_file"
 
+  # L1 EL via `l1_backend: anvil` - the single `anvil` service stands in for
+  # `el-1-geth-lighthouse` and serves the same JSON-RPC on 8545, but its name
+  # carries no `-el-N-` segment so the L1 EL block above skips it, leaving the
+  # published compose with no host binding for anvil. Bind it to host 8545 to
+  # match the geth mapping. anvil and el-1-geth-lighthouse are mutually
+  # exclusive (one L1 backend per enclave), so this is a no-op under the
+  # ethereum-package backend.
+  yq --in-place --yaml-output \
+    --arg enclave_name "$enclave_name" '
+        .services |= with_entries(
+            if .key | test("^" + $enclave_name + "-anvil") then
+                .value.ports = ["8545:8545"]
+            else . end
+        )
+    ' "$docker_compose_file"
+
   # L2 CL (consensus layer) - both the REST API (port 1317) and the cometBFT
   # RPC (port 26657) are mapped to the host. REST is what bridge tests and
   # checkpoint/milestone monitors hit; cometBFT RPC is what the heimdall

--- a/static_files/contracts/l1/deploy-lst-contracts.sh
+++ b/static_files/contracts/l1/deploy-lst-contracts.sh
@@ -23,15 +23,26 @@ CHECKPOINT_MANAGER=$(jq -re '.root.RootChainProxy' /opt/data/pos-addresses/contr
 ROOT_CHAIN_MANAGER=$(jq -re '.root.posBridge.RootChainManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
 CHILD_CHAIN_MANAGER=$(jq -re '.child.ChildChain' /opt/data/pos-addresses/contractAddresses.json)
 
-# Derive the sPOL deposit predicate from what RootChainManager ACTUALLY routes
-# keccak256("ERC20") deposits through — NOT the static .root.predicates.ERC20Predicate
-# json key. The messenger's initialize approves sPOL to this predicate, and the
-# migration's receiveMessage -> rootChainManager.depositFor(sPOL) pulls sPOL via
-# typeToPredicate(tokenType).transferFrom. If the json key and the registered
-# predicate ever diverge, the approval misses the real spender and depositFor
-# reverts ERC20InsufficientAllowance (0xfb8f41b2). Reading the live value
-# guarantees the approved spender == the spender depositFor uses.
-ERC20_PREDICATE=$(cast call --rpc-url "${L1_RPC_URL}" \
+# TWO DIFFERENT ERC20 predicates — the migration touches both bridges, and each
+# leg needs its own. Conflating them breaks the other leg (verified by tracing
+# both reverts on a live devnet):
+#
+#   * ERC20_PREDICATE  -> polBridger (input.json `erc20predicate`). polBridger.exitPOL
+#     calls IERC20PredicateBurnOnly(erc20predicate).startExitWithBurntTokens — a
+#     PLASMA exit. This must be the plasma ERC20PredicateBurnOnly at
+#     `.root.predicates.ERC20Predicate`. Pointing it at the pos-portal predicate
+#     makes startExitWithBurntTokens revert (~226 gas, no such fn).
+#
+#   * RCM_ERC20_PREDICATE -> messenger (input.json `rcmERC20Predicate`). The
+#     messenger's initialize approves sPOL to this predicate, and the migration's
+#     receiveMessage -> rootChainManager.depositFor(sPOL) pulls sPOL via
+#     RootChainManager.typeToPredicate(keccak256("ERC20")).transferFrom — a
+#     POS-PORTAL deposit. Approving the plasma predicate instead leaves the real
+#     pos-portal predicate unapproved -> depositFor reverts ERC20InsufficientAllowance
+#     (0xfb8f41b2). Derive it live from typeToPredicate so the approved spender is
+#     exactly the one depositFor uses.
+ERC20_PREDICATE=$(jq -re '.root.predicates.ERC20Predicate' /opt/data/pos-addresses/contractAddresses.json)
+RCM_ERC20_PREDICATE=$(cast call --rpc-url "${L1_RPC_URL}" \
   "${ROOT_CHAIN_MANAGER}" "typeToPredicate(bytes32)(address)" "$(cast keccak "ERC20")")
 STATE_SYNCER_L2="0x0000000000000000000000000000000000001001"
 POL_TOKEN_L2="0x0000000000000000000000000000000000001010"
@@ -60,7 +71,7 @@ jq -n \
   --arg erc20predicate "${ERC20_PREDICATE}" \
   --arg childChainManager "${CHILD_CHAIN_MANAGER}" \
   --arg rootChainManager "${ROOT_CHAIN_MANAGER}" \
-  --arg rcmERC20Predicate "${ERC20_PREDICATE}" \
+  --arg rcmERC20Predicate "${RCM_ERC20_PREDICATE}" \
   --arg depositManager "${DEPOSIT_MANAGER}" \
   --arg stateSenderL1 "${STATE_SENDER_L1}" \
   --arg checkpointManager "${CHECKPOINT_MANAGER}" \

--- a/static_files/contracts/l1/deploy-lst-contracts.sh
+++ b/static_files/contracts/l1/deploy-lst-contracts.sh
@@ -17,12 +17,22 @@ MATIC_TOKEN_L1=$(jq -re '.root.tokens.MaticToken' /opt/data/pos-addresses/contra
 POL_TOKEN_L1=$(jq -re '.root.tokens.PolToken' /opt/data/pos-addresses/contractAddresses.json)
 POLYGON_MIGRATION=$(jq -re '.root.tokens.PolygonMigration' /opt/data/pos-addresses/contractAddresses.json)
 WITHDRAW_MANAGER=$(jq -re '.root.WithdrawManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
-ERC20_PREDICATE=$(jq -re '.root.predicates.ERC20Predicate' /opt/data/pos-addresses/contractAddresses.json)
 DEPOSIT_MANAGER=$(jq -re '.root.DepositManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
 STATE_SENDER_L1=$(jq -re '.root.StateSender' /opt/data/pos-addresses/contractAddresses.json)
 CHECKPOINT_MANAGER=$(jq -re '.root.RootChainProxy' /opt/data/pos-addresses/contractAddresses.json)
 ROOT_CHAIN_MANAGER=$(jq -re '.root.posBridge.RootChainManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
 CHILD_CHAIN_MANAGER=$(jq -re '.child.ChildChain' /opt/data/pos-addresses/contractAddresses.json)
+
+# Derive the sPOL deposit predicate from what RootChainManager ACTUALLY routes
+# keccak256("ERC20") deposits through — NOT the static .root.predicates.ERC20Predicate
+# json key. The messenger's initialize approves sPOL to this predicate, and the
+# migration's receiveMessage -> rootChainManager.depositFor(sPOL) pulls sPOL via
+# typeToPredicate(tokenType).transferFrom. If the json key and the registered
+# predicate ever diverge, the approval misses the real spender and depositFor
+# reverts ERC20InsufficientAllowance (0xfb8f41b2). Reading the live value
+# guarantees the approved spender == the spender depositFor uses.
+ERC20_PREDICATE=$(cast call --rpc-url "${L1_RPC_URL}" \
+  "${ROOT_CHAIN_MANAGER}" "typeToPredicate(bytes32)(address)" "$(cast keccak "ERC20")")
 STATE_SYNCER_L2="0x0000000000000000000000000000000000001001"
 POL_TOKEN_L2="0x0000000000000000000000000000000000001010"
 FEE_RECEIVER_VALUE="${FEE_RECEIVER:-$ADMIN_ADDRESS}"

--- a/static_files/contracts/l1/deploy-lst-contracts.sh
+++ b/static_files/contracts/l1/deploy-lst-contracts.sh
@@ -106,6 +106,39 @@ jq -s '.[0] as $pos | .[1] as $spol
 echo "LST contracts deployed. Updated contractAddresses.json:"
 cat /opt/contracts/contractAddresses.json
 
+# Map sPOL in the PoS bridge (RootChainManager) so a migration's L1->L2 sPOL
+# re-deposit works. The migration's receiveMessage calls
+# `rootChainManager.depositFor(childTunnel, sPOL, ...)` (sPOLMessenger.sol),
+# which reverts "RootChainManager: TOKEN_NOT_MAPPED" until sPOL is mapped.
+# sPOL is a MintableERC20 child — `sPOLChild.deposit` is `onlyChildChainManager`
+# and the bridge MINTS on L2 / BURNS on L1, so the type is keccak256("MintableERC20")
+# (the MintableERC20 predicate is already registered by deploy-pos-bridge's
+# DummyMintableERC20 mapping). This mirrors the canonical governance step in
+# spol-contracts/script/BridgeMappingCalldata.s.sol; the deploy ran the sPOL
+# contracts but never mapped the token, so a real migration could not complete
+# on the devnet. The L1 mapToken state-syncs the L2 ChildChainManager side too
+# (RCM->CCM was paired in deploy-pos-bridge). ADMIN holds MAPPER_ROLE.
+SPOL_L1=$(jq -re '.sPOL_L1.sPOLProxy' script/deployment.json)
+SPOL_CHILD_L2=$(jq -re '.sPOL_L2.sPOLChildProxy' script/deployment.json)
+MINTABLE_ERC20_TYPE=$(cast keccak "MintableERC20")
+# Idempotency: the cl-el-genesis re-deploy runs this step twice; mapToken
+# reverts ALREADY_MAPPED on the second pass, so skip when already pointing at
+# the expected child (and fail loud if it points elsewhere — stale routing).
+spol_current_child=$(cast call --rpc-url "${L1_RPC_URL}" \
+  "${ROOT_CHAIN_MANAGER}" "rootToChildToken(address)(address)" "${SPOL_L1}")
+if [[ "${spol_current_child}" == "0x0000000000000000000000000000000000000000" ]]; then
+  echo "Mapping sPOL (${SPOL_L1} <-> ${SPOL_CHILD_L2}) as MintableERC20 on RootChainManager..."
+  cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" --legacy \
+    "${ROOT_CHAIN_MANAGER}" "mapToken(address,address,bytes32)" \
+    "${SPOL_L1}" "${SPOL_CHILD_L2}" "${MINTABLE_ERC20_TYPE}"
+elif [[ "${spol_current_child,,}" == "${SPOL_CHILD_L2,,}" ]]; then
+  echo "sPOL already mapped on RootChainManager to ${spol_current_child} — skipping"
+else
+  echo "ERROR: sPOL (${SPOL_L1}) is mapped to ${spol_current_child} on RootChainManager but" \
+    "this deploy produced ${SPOL_CHILD_L2}. L1 routes to a stale child contract." >&2
+  exit 1
+fi
+
 # Setup initial validators. Mirrors mainnet's canonical
 # spol-contracts/script/SetupInitialValidators.s.sol but ranges over kurtosis'
 # sequential validator ids (1..VALIDATOR_COUNT) rather than the mainnet/testnet

--- a/static_files/contracts/l1/deploy-lst-contracts.sh
+++ b/static_files/contracts/l1/deploy-lst-contracts.sh
@@ -21,34 +21,21 @@ DEPOSIT_MANAGER=$(jq -re '.root.DepositManagerProxy' /opt/data/pos-addresses/con
 STATE_SENDER_L1=$(jq -re '.root.StateSender' /opt/data/pos-addresses/contractAddresses.json)
 CHECKPOINT_MANAGER=$(jq -re '.root.RootChainProxy' /opt/data/pos-addresses/contractAddresses.json)
 ROOT_CHAIN_MANAGER=$(jq -re '.root.posBridge.RootChainManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
-# The POS-PORTAL ChildChainManager (mirrors .root.posBridge.RootChainManagerProxy
-# above) — NOT the legacy/plasma .child.ChildChain. This is the contract that
-# receives depositFor state-syncs on L2 and calls sPOLChild.deposit(); sPOLChild's
-# initialize wires it as the authorized childChainManager. Using .child.ChildChain
-# (a different address) makes sPOLChild.deposit revert AddressUnauthorized when the
-# pos-portal CCM delivers the migration-completion deposit — bor counts the
-# state-sync as consumed but rolls the effect back, so onGoingMigration never
-# flips false and the migration never completes on L2 (the sPOL is never credited).
+# pos-portal ChildChainManager (the one sPOLChild.initialize authorizes), NOT the
+# legacy plasma .child.ChildChain. With the wrong address the migration-completion
+# deposit reverts AddressUnauthorized in sPOLChild.deposit, so onGoingMigration
+# never flips and the migration never completes on L2.
 CHILD_CHAIN_MANAGER=$(jq -re '.child.posBridge.ChildChainManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
 
-# TWO DIFFERENT ERC20 predicates — the migration touches both bridges, and each
-# leg needs its own. Conflating them breaks the other leg (verified by tracing
-# both reverts on a live devnet):
-#
-#   * ERC20_PREDICATE  -> polBridger (input.json `erc20predicate`). polBridger.exitPOL
-#     calls IERC20PredicateBurnOnly(erc20predicate).startExitWithBurntTokens — a
-#     PLASMA exit. This must be the plasma ERC20PredicateBurnOnly at
-#     `.root.predicates.ERC20Predicate`. Pointing it at the pos-portal predicate
-#     makes startExitWithBurntTokens revert (~226 gas, no such fn).
-#
-#   * RCM_ERC20_PREDICATE -> messenger (input.json `rcmERC20Predicate`). The
-#     messenger's initialize approves sPOL to this predicate, and the migration's
-#     receiveMessage -> rootChainManager.depositFor(sPOL) pulls sPOL via
-#     RootChainManager.typeToPredicate(keccak256("ERC20")).transferFrom — a
-#     POS-PORTAL deposit. Approving the plasma predicate instead leaves the real
-#     pos-portal predicate unapproved -> depositFor reverts ERC20InsufficientAllowance
-#     (0xfb8f41b2). Derive it live from typeToPredicate so the approved spender is
-#     exactly the one depositFor uses.
+# The migration touches both bridges, so each leg needs its own ERC20 predicate
+# (conflating them reverts the other leg — both traced on a live devnet):
+#   * ERC20_PREDICATE -> erc20predicate: plasma ERC20PredicateBurnOnly, used by
+#     polBridger.exitPOL's startExitWithBurntTokens (pos-portal predicate has no
+#     such fn -> ~226-gas revert).
+#   * RCM_ERC20_PREDICATE -> rcmERC20Predicate: pos-portal predicate, the spender
+#     the messenger approves sPOL to and that depositFor pulls through. Derived
+#     live from typeToPredicate so it's exactly that spender (plasma predicate ->
+#     depositFor reverts ERC20InsufficientAllowance 0xfb8f41b2).
 ERC20_PREDICATE=$(jq -re '.root.predicates.ERC20Predicate' /opt/data/pos-addresses/contractAddresses.json)
 RCM_ERC20_PREDICATE=$(cast call --rpc-url "${L1_RPC_URL}" \
   "${ROOT_CHAIN_MANAGER}" "typeToPredicate(bytes32)(address)" "$(cast keccak "ERC20")")
@@ -135,28 +122,15 @@ jq -s '.[0] as $pos | .[1] as $spol
 echo "LST contracts deployed. Updated contractAddresses.json:"
 cat /opt/contracts/contractAddresses.json
 
-# Map sPOL in the PoS bridge (RootChainManager) so a migration's L1->L2 sPOL
-# re-deposit works. The migration's receiveMessage calls
-# `rootChainManager.depositFor(childTunnel, sPOL, ...)` (sPOLMessenger.sol),
-# which reverts "RootChainManager: TOKEN_NOT_MAPPED" until sPOL is mapped.
-# sPOL maps under keccak256("ERC20") — the PLAIN ERC20 type, NOT MintableERC20.
-# On L1 the RootChainManager treats sPOL as a standard locked ERC20: a migration's
-# receiveMessage calls `rootChainManager.depositFor(childTunnel, sPOL, ...)`
-# (sPOLMessenger.sol), and depositFor pulls sPOL from the messenger via
-# typeToPredicate(tokenType).transferFrom. The messenger's initialize approves
-# sPOL to the PLAIN ERC20Predicate (`sPOLToken.approve(_rcmERC20Predicate, max)`,
-# rcmERC20Predicate=ERC20_PREDICATE above), so the mapping MUST resolve to that
-# same predicate or depositFor reverts ERC20InsufficientAllowance (0xfb8f41b2).
-# deploy-pos-bridge registers ERC20Predicate under keccak256("ERC20"); mapping
-# under keccak256("MintableERC20") instead routes through the MintableERC20Predicate
-# (unapproved) and breaks the migration. This matches the canonical governance
-# step (spol-contracts/script/BridgeMappingCalldata.s.sol, literal
-# 0x8ae8...345b == keccak256("ERC20") — its "MintableERC20" comment is a mislabel)
-# and the spol-contracts migration integration tests (sPOLMigrationBackfill.t.sol,
-# sPOLControllerFullL1.t.sol), which both map with keccak256("ERC20"). The deploy
-# ran the sPOL contracts but never mapped the token, so a real migration could not
-# complete on the devnet. The L1 mapToken state-syncs the L2 ChildChainManager side
-# too (RCM->CCM was paired in deploy-pos-bridge). ADMIN holds MAPPER_ROLE.
+# Map sPOL in RootChainManager — the deploy ran the sPOL contracts but never
+# mapped the token, so the migration's receiveMessage -> depositFor(sPOL) reverts
+# TOKEN_NOT_MAPPED. Map under keccak256("ERC20") (plain ERC20), NOT MintableERC20:
+# deploy-pos-bridge registered ERC20Predicate under keccak256("ERC20") and that's
+# the spender the messenger approves, so the MintableERC20 type routes through an
+# unapproved predicate -> ERC20InsufficientAllowance (0xfb8f41b2). Matches the
+# canonical governance step (BridgeMappingCalldata.s.sol — its "MintableERC20"
+# comment is a mislabel; the literal is keccak256("ERC20")) and the migration
+# integration tests. mapToken state-syncs the L2 CCM side too; ADMIN holds MAPPER_ROLE.
 SPOL_L1=$(jq -re '.sPOL_L1.sPOLProxy' script/deployment.json)
 SPOL_CHILD_L2=$(jq -re '.sPOL_L2.sPOLChildProxy' script/deployment.json)
 ERC20_TYPE=$(cast keccak "ERC20")

--- a/static_files/contracts/l1/deploy-lst-contracts.sh
+++ b/static_files/contracts/l1/deploy-lst-contracts.sh
@@ -21,7 +21,15 @@ DEPOSIT_MANAGER=$(jq -re '.root.DepositManagerProxy' /opt/data/pos-addresses/con
 STATE_SENDER_L1=$(jq -re '.root.StateSender' /opt/data/pos-addresses/contractAddresses.json)
 CHECKPOINT_MANAGER=$(jq -re '.root.RootChainProxy' /opt/data/pos-addresses/contractAddresses.json)
 ROOT_CHAIN_MANAGER=$(jq -re '.root.posBridge.RootChainManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
-CHILD_CHAIN_MANAGER=$(jq -re '.child.ChildChain' /opt/data/pos-addresses/contractAddresses.json)
+# The POS-PORTAL ChildChainManager (mirrors .root.posBridge.RootChainManagerProxy
+# above) — NOT the legacy/plasma .child.ChildChain. This is the contract that
+# receives depositFor state-syncs on L2 and calls sPOLChild.deposit(); sPOLChild's
+# initialize wires it as the authorized childChainManager. Using .child.ChildChain
+# (a different address) makes sPOLChild.deposit revert AddressUnauthorized when the
+# pos-portal CCM delivers the migration-completion deposit — bor counts the
+# state-sync as consumed but rolls the effect back, so onGoingMigration never
+# flips false and the migration never completes on L2 (the sPOL is never credited).
+CHILD_CHAIN_MANAGER=$(jq -re '.child.posBridge.ChildChainManagerProxy' /opt/data/pos-addresses/contractAddresses.json)
 
 # TWO DIFFERENT ERC20 predicates — the migration touches both bridges, and each
 # leg needs its own. Conflating them breaks the other leg (verified by tracing

--- a/static_files/contracts/l1/deploy-lst-contracts.sh
+++ b/static_files/contracts/l1/deploy-lst-contracts.sh
@@ -110,27 +110,37 @@ cat /opt/contracts/contractAddresses.json
 # re-deposit works. The migration's receiveMessage calls
 # `rootChainManager.depositFor(childTunnel, sPOL, ...)` (sPOLMessenger.sol),
 # which reverts "RootChainManager: TOKEN_NOT_MAPPED" until sPOL is mapped.
-# sPOL is a MintableERC20 child — `sPOLChild.deposit` is `onlyChildChainManager`
-# and the bridge MINTS on L2 / BURNS on L1, so the type is keccak256("MintableERC20")
-# (the MintableERC20 predicate is already registered by deploy-pos-bridge's
-# DummyMintableERC20 mapping). This mirrors the canonical governance step in
-# spol-contracts/script/BridgeMappingCalldata.s.sol; the deploy ran the sPOL
-# contracts but never mapped the token, so a real migration could not complete
-# on the devnet. The L1 mapToken state-syncs the L2 ChildChainManager side too
-# (RCM->CCM was paired in deploy-pos-bridge). ADMIN holds MAPPER_ROLE.
+# sPOL maps under keccak256("ERC20") — the PLAIN ERC20 type, NOT MintableERC20.
+# On L1 the RootChainManager treats sPOL as a standard locked ERC20: a migration's
+# receiveMessage calls `rootChainManager.depositFor(childTunnel, sPOL, ...)`
+# (sPOLMessenger.sol), and depositFor pulls sPOL from the messenger via
+# typeToPredicate(tokenType).transferFrom. The messenger's initialize approves
+# sPOL to the PLAIN ERC20Predicate (`sPOLToken.approve(_rcmERC20Predicate, max)`,
+# rcmERC20Predicate=ERC20_PREDICATE above), so the mapping MUST resolve to that
+# same predicate or depositFor reverts ERC20InsufficientAllowance (0xfb8f41b2).
+# deploy-pos-bridge registers ERC20Predicate under keccak256("ERC20"); mapping
+# under keccak256("MintableERC20") instead routes through the MintableERC20Predicate
+# (unapproved) and breaks the migration. This matches the canonical governance
+# step (spol-contracts/script/BridgeMappingCalldata.s.sol, literal
+# 0x8ae8...345b == keccak256("ERC20") — its "MintableERC20" comment is a mislabel)
+# and the spol-contracts migration integration tests (sPOLMigrationBackfill.t.sol,
+# sPOLControllerFullL1.t.sol), which both map with keccak256("ERC20"). The deploy
+# ran the sPOL contracts but never mapped the token, so a real migration could not
+# complete on the devnet. The L1 mapToken state-syncs the L2 ChildChainManager side
+# too (RCM->CCM was paired in deploy-pos-bridge). ADMIN holds MAPPER_ROLE.
 SPOL_L1=$(jq -re '.sPOL_L1.sPOLProxy' script/deployment.json)
 SPOL_CHILD_L2=$(jq -re '.sPOL_L2.sPOLChildProxy' script/deployment.json)
-MINTABLE_ERC20_TYPE=$(cast keccak "MintableERC20")
+ERC20_TYPE=$(cast keccak "ERC20")
 # Idempotency: the cl-el-genesis re-deploy runs this step twice; mapToken
 # reverts ALREADY_MAPPED on the second pass, so skip when already pointing at
 # the expected child (and fail loud if it points elsewhere — stale routing).
 spol_current_child=$(cast call --rpc-url "${L1_RPC_URL}" \
   "${ROOT_CHAIN_MANAGER}" "rootToChildToken(address)(address)" "${SPOL_L1}")
 if [[ "${spol_current_child}" == "0x0000000000000000000000000000000000000000" ]]; then
-  echo "Mapping sPOL (${SPOL_L1} <-> ${SPOL_CHILD_L2}) as MintableERC20 on RootChainManager..."
+  echo "Mapping sPOL (${SPOL_L1} <-> ${SPOL_CHILD_L2}) as ERC20 on RootChainManager..."
   cast send --rpc-url "${L1_RPC_URL}" --private-key "${PRIVATE_KEY}" --legacy \
     "${ROOT_CHAIN_MANAGER}" "mapToken(address,address,bytes32)" \
-    "${SPOL_L1}" "${SPOL_CHILD_L2}" "${MINTABLE_ERC20_TYPE}"
+    "${SPOL_L1}" "${SPOL_CHILD_L2}" "${ERC20_TYPE}"
 elif [[ "${spol_current_child,,}" == "${SPOL_CHILD_L2,,}" ]]; then
   echo "sPOL already mapped on RootChainManager to ${spol_current_child} — skipping"
 else


### PR DESCRIPTION
Fixes that let an lst-api sPOL migration e2e run end-to-end on a kurtosis-pos devnet with the `anvil` L1 backend. Two independent areas, both root-caused by tracing on-chain reverts / inspecting the published snapshot on a live devnet.

## A. sPOL bridge mappings in the LST contract deploy

Three plasma-vs-pos-portal address mix-ups in `static_files/contracts/l1/deploy-lst-contracts.sh`. The sPOL migration crosses **both** PoS bridges (legacy plasma *and* pos-portal), and each leg must reference the contract for its own bridge; the deploy was conflating them.

### 1. Map sPOL in RootChainManager under `keccak256("ERC20")`
The deploy never mapped sPOL, so a migration's `receiveMessage → rootChainManager.depositFor(sPOL)` reverted `TOKEN_NOT_MAPPED`. Added an idempotent `mapToken` step that maps sPOL as the plain **`ERC20`** type (not `MintableERC20`), matching the canonical governance step (`spol-contracts/script/BridgeMappingCalldata.s.sol`) and the migration integration tests. Skips cleanly on the genesis re-deploy's second pass (`rootToChildToken` already set) and fails loud if L1 routes to a stale child.

### 2. Wire `sPOLChild` to the pos-portal ChildChainManager
`CHILD_CHAIN_MANAGER` was read from the legacy `.child.ChildChain`; it must be the pos-portal `.child.posBridge.ChildChainManagerProxy` — the contract `sPOLChild.initialize` authorizes. With the wrong address the migration-completion deposit hit `sPOLChild.deposit` and reverted `AddressUnauthorized`; bor counted the state-sync as consumed but rolled the effect back, so `onGoingMigration` never flipped and the migration never completed on L2.

### 3. Split the two ERC20 predicates
`rcmERC20Predicate` was incorrectly set to the plasma `ERC20Predicate`. The two legs need distinct predicates:
- **`erc20predicate`** → plasma `ERC20PredicateBurnOnly` (`.root.predicates.ERC20Predicate`), used by `polBridger.exitPOL`'s `startExitWithBurntTokens`. Pointing it at the pos-portal predicate reverts (~226 gas, no such fn).
- **`rcmERC20Predicate`** → pos-portal predicate, derived live from `RootChainManager.typeToPredicate(keccak256("ERC20"))`, used by the messenger's `depositFor`. Approving the plasma predicate instead leaves the real spender unapproved → `depositFor` reverts `ERC20InsufficientAllowance` (`0xfb8f41b2`).

## B. anvil L1 backend support in the snapshot pipeline

The snapshot pipeline (`scripts/snapshot/`) assumed the ethereum-package L1 backend; two gaps broke it under `l1_backend: anvil` (lst-api's shape), each currently worked around inside lst-api's snapshot scripts.

### 1. Bind anvil's RPC port (`configure_ports`)
`configure_ports` only added host port bindings for services matching `-el-N-` / `-l2-el-N-`. The `anvil` service has no `-el-N-` segment, so it was skipped and the published compose exposed no host port for anvil — `localhost:8545` was unbound after `docker compose up`. Now bound to host 8545, mirroring the `el-1-geth-lighthouse` mapping.

### 2. Preserve anvil's chain state across snapshot/restore
`snapshot.sh` captured every docker volume but not anvil's chain state: anvil dumps state only to `/tmp` (not a captured volume) and only on SIGINT (not the SIGTERM the stop sequence sends), so a restored devnet came up on bare genesis with every deployed L1 contract missing. `snapshot.sh` now captures the live post-deploy state via the `anvil_dumpState` RPC (after checkpoint quiescence) into the captured `/opt/anvil` volume, and `restore.sh` replays it via `anvil_loadState` once the devnet is up. Both legs no-op under the ethereum-package backend (no anvil service).

## Verification

- **A** is consumed by **lst-api PR #140**: the kurtosis migration-walk e2e (`idle → exitPOL → finalizeExitPOL → receiveMessage → L2-completion → auto-resume → idle`) is green only with all three deploy fixes.
- **B** lets lst-api drop the matching bespoke workarounds in its snapshot scripts (the `pos-anvil` compose port-patch, and the `anvil_dumpState`/`anvil_loadState` capture/replay). The `anvil_dumpState`/`loadState` RPC round-trip was confirmed against this devnet's anvil image (`foundry v1.6.0-rc1`); full snapshot/restore integration is validated via lst-api's e2e snapshot rebuild against this branch.

`e2e-trigger.yml` in lst-api currently pins `KURTOSIS_POS_REF` to this branch; once merged + tagged, that pin moves to the tag.